### PR TITLE
Add historical and aggregate reads

### DIFF
--- a/opcua-local-server/client_example.py
+++ b/opcua-local-server/client_example.py
@@ -56,7 +56,7 @@ def main():
                 for history_data_value in history_data:
                         print(f"  {sensor_name}: {history_data_value.Value.Value:.2f} @ {history_data_value.SourceTimestamp}")
             except Exception as e:
-                print(f"  Error reading {sensor_name}: {e}")
+                print(f"  ⚠️ Error reading {sensor_name}: {e}")
         
         # === CONTROLLING ACTUATORS ===
         print("\n⚙️ Controlling Actuators:")
@@ -106,7 +106,7 @@ def main():
             start_cmd_node.set_value(25.0)
             print(f"  Start production command sent: 25.0")
         except Exception as e:
-            print(f"  Error sending start production command: {e}")
+            print(f"  ⚠️ Error sending start production command: {e}")
         
         # Wait a moment for changes to take effect
         time.sleep(3)
@@ -126,7 +126,7 @@ def main():
                 value = sensor_node.get_value()
                 print(f"  {sensor_name}: {value:.2f}")
             except Exception as e:
-                print(f"  Error reading {sensor_name}: {e}")
+                print(f"  ⚠️ Error reading {sensor_name}: {e}")
         
         # Check pump status
         pump_node = actuators.get_child(["2:PumpEnabled"])
@@ -141,7 +141,7 @@ def main():
             stop_cmd_node.set_value(True)
             print(f"  Stop production command sent")
         except Exception as e:
-            print(f"  Error sending stop production command: {e}")
+            print(f"  ⚠️ Error sending stop production command: {e}")
         
         # Final status check
         time.sleep(2)
@@ -168,7 +168,7 @@ def main():
             print(f"  System Mode: {mode}")
             
         except Exception as e:
-            print(f"  Error testing emergency stop: {e}")
+            print(f"  ⚠️ Error testing emergency stop: {e}")
         
         # Reset system
         print("\n🔄 Resetting System:")
@@ -184,7 +184,7 @@ def main():
             print(f"  System Mode: {mode}")
             
         except Exception as e:
-            print(f"  Error resetting system: {e}")
+            print(f"  ⚠️ Error resetting system: {e}")
         
         print("\n✅ Demo completed successfully!")
         

--- a/opcua-local-server/client_example.py
+++ b/opcua-local-server/client_example.py
@@ -6,6 +6,7 @@ This demonstrates how to connect to and interact with the server.
 
 import time
 import logging
+from datetime import datetime, timedelta
 from opcua import Client, ua
 
 
@@ -48,6 +49,12 @@ def main():
                 sensor_node = sensors.get_child([f"2:{sensor_name}"])
                 value = sensor_node.get_value()
                 print(f"  {sensor_name}: {value:.2f}")
+
+                endtime = datetime.utcnow()
+                starttime = endtime - timedelta(hours=1)
+                history_data = sensor_node.read_raw_history(starttime, endtime, 5)
+                for history_data_value in history_data:
+                        print(f"  {sensor_name}: {history_data_value.Value.Value:.2f} @ {history_data_value.SourceTimestamp}")
             except Exception as e:
                 print(f"  Error reading {sensor_name}: {e}")
         

--- a/opcua-local-server/opcua_local_server.py
+++ b/opcua-local-server/opcua_local_server.py
@@ -74,6 +74,9 @@ class IndustrialControlSystem:
         logging.info("Address space setup completed")
     
     def historize(self):
+        accessHistoryDataCapability = self.server.get_node("ns=0;i=11193")
+        accessHistoryDataCapability.set_value(True)
+
         objects = self.server.get_objects_node()
         industrial_system = objects.get_child("2:IndustrialControlSystem")
         for child in industrial_system.get_children():
@@ -477,7 +480,7 @@ def main():
     try:
         # Setup the address space
         industrial_system.setup_address_space()
-        
+
         # Start the server
         server.start()
         industrial_system.historize()

--- a/opcua-local-server/opcua_local_server.py
+++ b/opcua-local-server/opcua_local_server.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import random
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Dict, Any
 
 from opcua import Server, ua
@@ -73,6 +73,16 @@ class IndustrialControlSystem:
         
         logging.info("Address space setup completed")
     
+    def historize(self):
+        objects = self.server.get_objects_node()
+        industrial_system = objects.get_child("2:IndustrialControlSystem")
+        for child in industrial_system.get_children():
+            for variable in child.get_variables():
+                logging.info(f"historize {child.get_display_name().to_string()};{variable.get_display_name().to_string()}")
+                self.server.historize_node_data_change(variable, period=timedelta(minutes=10), count=0)
+
+        logging.info("historize completed")
+
     def _create_sensor_variables(self, parent_folder: Node):
         """Create sensor variables with proper data types and descriptions."""
         
@@ -268,7 +278,7 @@ class IndustrialControlSystem:
             # Add some calibration effect
             pass
         return True
-    
+
     def simulate_process(self):
         """Simulate industrial process behavior."""
         while self.running:
@@ -470,6 +480,7 @@ def main():
         
         # Start the server
         server.start()
+        industrial_system.historize()
         logging.info("OPC UA Server started at opc.tcp://0.0.0.0:4840/freeopcua/server/")
         logging.info("Server is running and ready for connections")
         

--- a/opcua-local-server/pyproject.toml
+++ b/opcua-local-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opcua-local-server"
-version = "0.1.0"
+version = "0.1.2"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/opcua-mcp-npx-server/README.md
+++ b/opcua-mcp-npx-server/README.md
@@ -5,6 +5,7 @@ An NPX-based Model Context Protocol (MCP) server for OPC UA operations. This ser
 ## Features
 
 - **Read OPC UA Nodes**: Read values from individual or multiple OPC UA nodes
+- **Read History OPC UA Node**: Read the historical values of a specific OPC UA node
 - **Write OPC UA Nodes**: Write values to individual or multiple OPC UA nodes  
 - **Browse Node Children**: Explore the OPC UA address space by browsing node children
 - **Call OPC UA Methods**: Execute methods on OPC UA objects with parameters
@@ -66,7 +67,27 @@ Read the value of a specific OPC UA node.
   "node_id": "ns=2;i=1"
 }
 ```
-### 2. write_opcua_node
+
+### 2. read_history_opcua_node
+
+Read the historical values of a specific OPC UA node.
+
+**Parameters:**
+- `node_id` (string): The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'
+- `start_time` (datetime)
+- `end_time` (datetime)
+- `num_values` (int): Number of values to read (default: unlimited)
+
+**Example:**
+```json
+{
+  "node_id": "ns=2;i=1",
+  "start_time": "2026-04-23 17:40:00",
+  "end_time": "2026-04-23 17:45:00"
+}
+```
+
+### 3. write_opcua_node
 
 Write a value to a specific OPC UA node.
 
@@ -82,7 +103,7 @@ Write a value to a specific OPC UA node.
 }
 ```
 
-### 3. browse_opcua_node_children
+### 4. browse_opcua_node_children
 
 Browse the children of a specific OPC UA node.
 
@@ -96,7 +117,7 @@ Browse the children of a specific OPC UA node.
 }
 ```
 
-### 4. read_multiple_opcua_nodes
+### 5. read_multiple_opcua_nodes
 
 Read values from multiple OPC UA nodes in a single request.
 
@@ -114,7 +135,7 @@ Read values from multiple OPC UA nodes in a single request.
 }
 ```
 
-### 5. write_multiple_opcua_nodes
+### 6. write_multiple_opcua_nodes
 
 Write values to multiple OPC UA nodes in a single request.
 
@@ -131,7 +152,7 @@ Write values to multiple OPC UA nodes in a single request.
 }
 ```
 
-### 6. call_opcua_method
+### 7. call_opcua_method
 
 Call a method on a specific OPC UA object node.
 
@@ -149,7 +170,7 @@ Call a method on a specific OPC UA object node.
 }
 ```
 
-### 7. get_all_variables
+### 8. get_all_variables
 
 Get all available variables from the OPC UA server, excluding those under the built-in 'Server' object.
 

--- a/opcua-mcp-npx-server/README.md
+++ b/opcua-mcp-npx-server/README.md
@@ -5,7 +5,6 @@ An NPX-based Model Context Protocol (MCP) server for OPC UA operations. This ser
 ## Features
 
 - **Read OPC UA Nodes**: Read values from individual or multiple OPC UA nodes
-- **Read History OPC UA Node**: Read the historical values of a specific OPC UA node
 - **Write OPC UA Nodes**: Write values to individual or multiple OPC UA nodes  
 - **Browse Node Children**: Explore the OPC UA address space by browsing node children
 - **Call OPC UA Methods**: Execute methods on OPC UA objects with parameters
@@ -13,6 +12,8 @@ An NPX-based Model Context Protocol (MCP) server for OPC UA operations. This ser
 - **Get All Variables**: Discover all available variables in the OPC UA server address space
 - **Automatic Type Conversion**: Intelligent conversion of values based on node data types
 - **Connection Management**: Automatic connection handling with graceful disconnection
+- **Read History OPC UA Node**: Read the historical values of a specific OPC UA node (if supported by the server)
+- **Read Aggregate OPC UA Node**: Calculate the historical aggregates (if supported by the server)
 
 ## Installation & Usage
 
@@ -68,7 +69,105 @@ Read the value of a specific OPC UA node.
 }
 ```
 
-### 2. read_history_opcua_node
+### 2. write_opcua_node
+
+Write a value to a specific OPC UA node.
+
+**Parameters:**
+- `node_id` (string): The OPC UA node ID
+- `value` (string): The value to write (automatically converted to the correct type)
+
+**Example:**
+```json
+{
+  "node_id": "ns=2;i=2",
+  "value": "75.5"
+}
+```
+
+### 3. browse_opcua_node_children
+
+Browse the children of a specific OPC UA node.
+
+**Parameters:**
+- `node_id` (string): The OPC UA node ID to browse
+
+**Example:**
+```json
+{
+  "node_id": "ns=2;i=3"
+}
+```
+
+### 4. read_multiple_opcua_nodes
+
+Read values from multiple OPC UA nodes in a single request.
+
+**Parameters:**
+- `node_ids` (array): List of OPC UA node IDs to read
+
+**Example:**
+```json
+{
+  "node_ids": [
+    "ns=2;i=4", 
+    "ns=2;i=5", 
+    "ns=2;i=6"
+  ]
+}
+```
+
+### 5. write_multiple_opcua_nodes
+
+Write values to multiple OPC UA nodes in a single request.
+
+**Parameters:**
+- `nodes_to_write` (array): List of objects containing 'node_id' and 'value'
+
+**Example:**
+```json
+{
+  "nodes_to_write": [
+    {"node_id": "ns=2;i=7", "value": "50"},
+    {"node_id": "ns=2;i=8", "value": "true"}
+  ]
+}
+```
+
+### 6. call_opcua_method
+
+Call a method on a specific OPC UA object node.
+
+**Parameters:**
+- `object_node_id` (string): The OPC UA node ID of the object containing the method
+- `method_node_id` (string): The OPC UA node ID of the method to call
+- `arguments` (array, optional): List of arguments to pass to the method
+
+**Example:**
+```json
+{
+  "object_node_id": "ns=2;i=9",
+  "method_node_id": "ns=2;i=10",
+  "arguments": ["25.0", "high_quality"]
+}
+```
+
+### 7. get_all_variables
+
+Get all available variables from the OPC UA server, excluding those under the built-in 'Server' object.
+
+**Parameters:**
+- None required
+
+**Example:**
+```json
+{}
+```
+
+**Returns:**
+A comprehensive list of all variables with their properties including name, node ID, object ID, current value, data type, and description.
+
+### 8. read_history_opcua_node
 
 Read the historical values of a specific OPC UA node.
 
@@ -87,103 +186,27 @@ Read the historical values of a specific OPC UA node.
 }
 ```
 
-### 3. write_opcua_node
+### 9. read_aggregate_opcua_node
 
-Write a value to a specific OPC UA node.
+Calculate the historical aggregates over a defined time range, divided into smaller chunks defined by the `processing_interval` (in milliseconds). The server divides the [`start_time`, `end_time`] domain into these intervals, returning one aggregated value per interval.
 
 **Parameters:**
-- `node_id` (string): The OPC UA node ID
-- `value` (string): The value to write (automatically converted to the correct type)
+- `node_id` (string): The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'
+- `start_time` (datetime): Beginning of the retrieval
+- `end_time` (datetime): End of the retrieval (defaults to 'now')
+- `aggregate_function` (string): The specific formula, e.g. Average, Minimum, Maximum
+- `processing_interval` (number): The duration (ms) for each computed value. If set to 0, the server calculates a single aggregate value for the entire range.
 
 **Example:**
 ```json
 {
-  "node_id": "ns=2;i=2",
-  "value": "75.5"
+  "node_id": "ns=2;i=1",
+  "start_time": "2026-04-23 17:40:00",
+  "end_time": "2026-04-23 17:45:00",
+  "aggregate_function": "Average",
+  "processing_interval": "60000"
 }
 ```
-
-### 4. browse_opcua_node_children
-
-Browse the children of a specific OPC UA node.
-
-**Parameters:**
-- `node_id` (string): The OPC UA node ID to browse
-
-**Example:**
-```json
-{
-  "node_id": "ns=2;i=3"
-}
-```
-
-### 5. read_multiple_opcua_nodes
-
-Read values from multiple OPC UA nodes in a single request.
-
-**Parameters:**
-- `node_ids` (array): List of OPC UA node IDs to read
-
-**Example:**
-```json
-{
-  "node_ids": [
-    "ns=2;i=4", 
-    "ns=2;i=5", 
-    "ns=2;i=6"
-  ]
-}
-```
-
-### 6. write_multiple_opcua_nodes
-
-Write values to multiple OPC UA nodes in a single request.
-
-**Parameters:**
-- `nodes_to_write` (array): List of objects containing 'node_id' and 'value'
-
-**Example:**
-```json
-{
-  "nodes_to_write": [
-    {"node_id": "ns=2;i=7", "value": "50"},
-    {"node_id": "ns=2;i=8", "value": "true"}
-  ]
-}
-```
-
-### 7. call_opcua_method
-
-Call a method on a specific OPC UA object node.
-
-**Parameters:**
-- `object_node_id` (string): The OPC UA node ID of the object containing the method
-- `method_node_id` (string): The OPC UA node ID of the method to call
-- `arguments` (array, optional): List of arguments to pass to the method
-
-**Example:**
-```json
-{
-  "object_node_id": "ns=2;i=9",
-  "method_node_id": "ns=2;i=10",
-  "arguments": ["25.0", "high_quality"]
-}
-```
-
-### 8. get_all_variables
-
-Get all available variables from the OPC UA server, excluding those under the built-in 'Server' object.
-
-**Parameters:**
-- None required
-
-**Example:**
-```json
-{}
-```
-
-**Returns:**
-A comprehensive list of all variables with their properties including name, node ID, object ID, current value, data type, and description.
 
 ## Integration with Cursor/Claude
 

--- a/opcua-mcp-npx-server/package-lock.json
+++ b/opcua-mcp-npx-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opcua-mcp-npx-server",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opcua-mcp-npx-server",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/opcua-mcp-npx-server/package.json
+++ b/opcua-mcp-npx-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opcua-mcp-npx-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "NPX-based MCP server for OPC UA control - Model Context Protocol server for OPC UA operations",
   "main": "src/index.js",
   "type": "module",

--- a/opcua-mcp-npx-server/src/index.ts
+++ b/opcua-mcp-npx-server/src/index.ts
@@ -20,7 +20,8 @@ import {
   CallMethodResult,
   BrowseResult,
   ReferenceDescription,
-  HistoryData
+  HistoryData,
+  AggregateFunction,
 } from "node-opcua";
 import { DateTime } from "node-opcua-basic-types";
 
@@ -31,6 +32,7 @@ class OPCUAMCPServer {
   private server: Server;
   private opcuaClient: OPCUAClient | null = null;
   private session: ClientSession | null = null;
+  private aggregateFunctions: string[] = [];
 
   constructor() {
     this.server = new Server(
@@ -121,6 +123,38 @@ class OPCUAMCPServer {
       dataValue.statusCode === StatusCodes.Good &&
       dataValue.value?.value === true
     );
+  }
+
+  private async serverCapabilitiesAggregateFunctions(): Promise<string[]> {
+    await this.ensureConnection();
+    let aggregateFunctions: string[] = [];
+    try {
+      const browseResult = await this.session!.browse({
+        nodeId: "ns=0;i=2997", // AggregateFunctions
+        browseDirection: 0, // Forward
+        resultMask: 63, // All information (including BrowseName)
+      });
+      if (
+        browseResult.statusCode === StatusCodes.Good &&
+        browseResult.references
+      ) {
+        for (const reference of browseResult.references) {
+          // Map the string BrowseName to the AggregateFunction
+          if (reference.browseName.name) {
+            const name = reference.browseName.name.toString();
+            if (name in AggregateFunction) {
+              aggregateFunctions.push(name);
+            }
+          }
+        }
+      }
+    } catch (error) {
+      console.error(
+        "Error during serverCapabilitiesAggregateFunctions:",
+        error,
+      );
+    }
+    return aggregateFunctions;
   }
 
   private setupToolHandlers() {
@@ -281,6 +315,41 @@ class OPCUAMCPServer {
         tools.push(t);
       }
 
+      this.aggregateFunctions = await this.serverCapabilitiesAggregateFunctions();
+      if (this.aggregateFunctions.length > 0) {
+        const t = {
+          name: "read_aggregate_opcua_node",
+          description: "Calculate the historical aggregates over a defined time range, divided into smaller chunks defined by the `processing_interval` (in milliseconds). The server divides the [`start_time`, `end_time`] domain into these intervals, returning one aggregated value per interval",
+          inputSchema: {
+            type: "object",
+            properties: {
+              node_id: {
+                type: "string",
+                description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=2'."
+              },
+              start_time: {
+                type: "string",
+                description: "Beginning of the retrieval"
+              },
+              end_time: {
+                type: "string",
+                description: "End of the retrieval (defaults to 'now')"
+              },
+              aggregate_function: {
+                type: "string",
+                description: "The specific formula, one of: " + [...this.aggregateFunctions].join(", ")
+              },
+              processing_interval: {
+                type: "number",
+                description: "The duration (ms) for each computed value. If set to 0, the server calculates a single aggregate value for the entire range."
+              }
+            },
+            required: ["node_id", "start_time", "aggregate_function"]
+          }
+        } satisfies Tool;
+        tools.push(t);
+      }
+
       return { tools };
     });
 
@@ -300,6 +369,15 @@ class OPCUAMCPServer {
               args?.start_time as DateTime,
               args?.end_time as DateTime,
               (args?.num_values as number) || 0,
+            );
+
+          case "read_aggregate_opcua_node":
+            return await this.readAggregateOpcuaNode(
+              args?.node_id as string,
+              args?.start_time as DateTime,
+              (args?.end_time as DateTime) || new Date(),
+              args?.aggregate_function as string,
+              (args?.processing_interval as number) || 0,
             );
 
           case "write_opcua_node":
@@ -392,6 +470,47 @@ class OPCUAMCPServer {
         throw new Error(`Read history failed with status: ${historyValues[0].statusCode.toString()}`);
       }
       const dataValues = (historyValues[0].historyData as HistoryData).dataValues;
+      return {
+        content: [
+          {
+            type: "text",
+            text: `${JSON.stringify(dataValues, null, 2)}`
+          }
+        ]
+      };
+    } catch (error) {
+      throw new Error(`Failed to read node ${nodeId}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  private async readAggregateOpcuaNode(
+    nodeId: string,
+    start: DateTime,
+    end: DateTime,
+    aggregate_fn: string,
+    processing_interval: number,
+  ) {
+    if (!this.session) {
+      throw new Error("No OPC UA session available");
+    }
+
+    if (!this.aggregateFunctions.includes(aggregate_fn)) {
+      throw new Error("Invalid aggregate function");
+    }
+
+    try {
+      const aggregateFn = AggregateFunction[aggregate_fn as keyof typeof AggregateFunction];
+      const historyValues = await this.session.readAggregateValue(
+        { nodeId },
+        start,
+        end,
+        aggregateFn,
+        processing_interval,
+      );
+      if (historyValues.statusCode !== StatusCodes.Good) {
+        throw new Error(`Read aggregate failed with status: ${historyValues.statusCode.toString()}`);
+      }
+      const dataValues = (historyValues.historyData as HistoryData).dataValues;
       return {
         content: [
           {

--- a/opcua-mcp-npx-server/src/index.ts
+++ b/opcua-mcp-npx-server/src/index.ts
@@ -19,8 +19,10 @@ import {
   StatusCodes,
   CallMethodResult,
   BrowseResult,
-  ReferenceDescription
+  ReferenceDescription,
+  HistoryData
 } from "node-opcua";
+import { DateTime } from "node-opcua-basic-types";
 
 // OPC UA client configuration
 const SERVER_URL = process.env.OPCUA_SERVER_URL || "opc.tcp://localhost:4840";
@@ -128,6 +130,30 @@ class OPCUAMCPServer {
                 }
               },
               required: ["node_id"]
+            }
+          },
+          {
+            name: "read_history_opcua_node",
+            description: "Read the historical values of a specific OPC UA node",
+            inputSchema: {
+              type: "object",
+              properties: {
+                node_id: {
+                  type: "string",
+                  description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=2'."
+                },
+                start_time: {
+                  type: "datetime"
+                },
+                end_time: {
+                  type: "datetime"
+                },
+                num_values: {
+                  type: "int",
+                  description: "Number of values to read (default: unlimited)"
+                },
+              },
+              required: ["node_id", "starttime", "endtime"]
             }
           },
           {
@@ -253,6 +279,9 @@ class OPCUAMCPServer {
           case "read_opcua_node":
             return await this.readOpcuaNode(args?.node_id as string);
 
+          case "read_history_opcua_node":
+            return await this.readHistoryOpcuaNode(args?.node_id as string, args?.start_time as DateTime, args?.end_time as DateTime, (args?.num_values as number) || 0);
+
           case "write_opcua_node":
             return await this.writeOpcuaNode(args?.node_id as string, args?.value as string);
 
@@ -309,6 +338,38 @@ class OPCUAMCPServer {
           {
             type: "text",
             text: `Node ${nodeId} value: ${value}`
+          }
+        ]
+      };
+    } catch (error) {
+      throw new Error(`Failed to read node ${nodeId}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  private async readHistoryOpcuaNode(nodeId: string,
+                                     start: DateTime,
+                                     end: DateTime,
+                                     numValuesPerNode: number) {
+    if (!this.session) {
+      throw new Error("No OPC UA session available");
+    }
+
+    try {
+      const historyValues = await this.session.readHistoryValue([nodeId], start, end, {
+        numValuesPerNode
+      });
+      if (historyValues.length !== 1) {
+        throw new Error(`Read hisstory failed`);
+      }
+      if (historyValues[0].statusCode !== StatusCodes.Good) {
+        throw new Error(`Read hisstory failed with status: ${historyValues[0].statusCode.toString()}`);
+      }
+      const dataValues = (historyValues[0].historyData as HistoryData).dataValues;
+      return {
+        content: [
+          {
+            type: "text",
+            text: `${JSON.stringify(dataValues, null, 2)}`
           }
         ]
       };

--- a/opcua-mcp-npx-server/src/index.ts
+++ b/opcua-mcp-npx-server/src/index.ts
@@ -7,7 +7,7 @@ import {
   ListToolsRequestSchema,
   Tool,
 } from "@modelcontextprotocol/sdk/types.js";
-import { 
+import {
   OPCUAClient,
   MessageSecurityMode,
   SecurityPolicy,
@@ -112,6 +112,15 @@ class OPCUAMCPServer {
     if (!this.opcuaClient || !this.session) {
       await this.connect();
     }
+  }
+
+  private async accessHistoryDataCapability(): Promise<boolean> {
+    await this.ensureConnection();
+    const dataValue = await this.session!.readVariableValue("ns=0;i=11193"); // AccessHistoryDataCapability
+    return (
+      dataValue.statusCode === StatusCodes.Good &&
+      dataValue.value?.value === true
+    );
   }
 
   private setupToolHandlers() {
@@ -242,36 +251,34 @@ class OPCUAMCPServer {
         }
       ] satisfies Tool[];
 
-      await this.ensureConnection();
-      if (this.session) {
-        const dataValue = await this.session.readVariableValue("ns=0;i=11193"); // AccessHistoryDataCapability
-        if (dataValue.statusCode === StatusCodes.Good && dataValue.value?.value === true) {
-          const t = {
-            name: "read_history_opcua_node",
-            description: "Read the historical values of a specific OPC UA node",
-            inputSchema: {
-              type: "object",
-              properties: {
-                node_id: {
-                  type: "string",
-                  description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=2'."
-                },
-                start_time: {
-                  type: "string"
-                },
-                end_time: {
-                  type: "string"
-                },
-                num_values: {
-                  type: "number",
-                  description: "Number of values to read (default: unlimited)"
-                },
+      if (await this.accessHistoryDataCapability()) {
+        const t = {
+          name: "read_history_opcua_node",
+          description: "Read the historical values of a specific OPC UA node",
+          inputSchema: {
+            type: "object",
+            properties: {
+              node_id: {
+                type: "string",
+                description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=2'."
               },
-              required: ["node_id"]
-            }
-          } satisfies Tool;
-          tools.push(t);
-        }
+              start_time: {
+                type: "string",
+                description: "Beginning of the retrieval"
+              },
+              end_time: {
+                type: "string",
+                description: "End of the retrieval"
+              },
+              num_values: {
+                type: "number",
+                description: "Number of values to read (default: unlimited)"
+              },
+            },
+            required: ["node_id"]
+          }
+        } satisfies Tool;
+        tools.push(t);
       }
 
       return { tools };
@@ -288,7 +295,12 @@ class OPCUAMCPServer {
             return await this.readOpcuaNode(args?.node_id as string);
 
           case "read_history_opcua_node":
-            return await this.readHistoryOpcuaNode(args?.node_id as string, args?.start_time as DateTime, args?.end_time as DateTime, (args?.num_values as number) || 0);
+            return await this.readHistoryOpcuaNode(
+              args?.node_id as string,
+              args?.start_time as DateTime,
+              args?.end_time as DateTime,
+              (args?.num_values as number) || 0,
+            );
 
           case "write_opcua_node":
             return await this.writeOpcuaNode(args?.node_id as string, args?.value as string);
@@ -335,7 +347,7 @@ class OPCUAMCPServer {
 
     try {
       const dataValue = await this.session.readVariableValue(nodeId);
-      
+
       if (dataValue.statusCode !== StatusCodes.Good) {
         throw new Error(`Read failed with status: ${dataValue.statusCode.toString()}`);
       }
@@ -354,18 +366,25 @@ class OPCUAMCPServer {
     }
   }
 
-  private async readHistoryOpcuaNode(nodeId: string,
-                                     start: DateTime,
-                                     end: DateTime,
-                                     numValuesPerNode: number) {
+  private async readHistoryOpcuaNode(
+    nodeId: string,
+    start: DateTime,
+    end: DateTime,
+    numValuesPerNode: number,
+  ) {
     if (!this.session) {
       throw new Error("No OPC UA session available");
     }
 
     try {
-      const historyValues = await this.session.readHistoryValue([nodeId], start, end, {
-        numValuesPerNode
-      });
+      const historyValues = await this.session.readHistoryValue(
+        [nodeId],
+        start,
+        end,
+        {
+          numValuesPerNode,
+        },
+      );
       if (historyValues.length !== 1) {
         throw new Error(`Read history failed`);
       }
@@ -394,10 +413,10 @@ class OPCUAMCPServer {
     try {
       // First read the current value to determine the data type
       const currentDataValue = await this.session.readVariableValue(nodeId);
-      
+
       let convertedValue: any;
       const currentValue = currentDataValue.value?.value;
-      
+
       // Convert value based on the current type
       if (typeof currentValue === 'number') {
         convertedValue = parseFloat(value);
@@ -419,7 +438,7 @@ class OPCUAMCPServer {
       };
 
       const statusCode = await this.session.write(nodeToWrite);
-      
+
       if (statusCode !== StatusCodes.Good) {
         throw new Error(`Write failed with status: ${statusCode.toString()}`);
       }
@@ -444,7 +463,7 @@ class OPCUAMCPServer {
 
     try {
       const browseResult = await this.session.browse(nodeId);
-      
+
       if (browseResult.statusCode !== StatusCodes.Good) {
         throw new Error(`Browse failed with status: ${browseResult.statusCode.toString()}`);
       }
@@ -479,9 +498,9 @@ class OPCUAMCPServer {
       }));
 
       const dataValues = await this.session.read(nodesToRead);
-      
+
       const results: { [key: string]: any } = {};
-      
+
       dataValues.forEach((dataValue, index) => {
         const nodeId = nodeIds[index];
         if (dataValue.statusCode === StatusCodes.Good) {
@@ -518,13 +537,13 @@ class OPCUAMCPServer {
       }));
 
       const currentDataValues = await this.session.read(nodesToRead);
-      
+
       const writeNodes = nodesToWrite.map((item, index) => {
         const currentDataValue = currentDataValues[index];
         const currentValue = currentDataValue.value?.value;
-        
+
         let convertedValue: any;
-        
+
         // Convert value based on the current type
         if (typeof currentValue === 'number') {
           convertedValue = parseFloat(item.value);
@@ -541,16 +560,16 @@ class OPCUAMCPServer {
           nodeId: item.node_id,
           attributeId: AttributeIds.Value,
           value: new DataValue({
-            value: new Variant({ 
-              dataType: currentDataValue.value?.dataType || DataType.String, 
-              value: convertedValue 
+            value: new Variant({
+              dataType: currentDataValue.value?.dataType || DataType.String,
+              value: convertedValue
             })
           })
         };
       });
 
       const statusCodes = await this.session.write(writeNodes);
-      
+
       const results = statusCodes.map((statusCode, index) => ({
         node_id: nodesToWrite[index].node_id,
         status: statusCode === StatusCodes.Good ? 'Success' : `Error: ${statusCode.toString()}`
@@ -577,12 +596,12 @@ class OPCUAMCPServer {
     try {
       // Convert string arguments to appropriate types
       const convertedArgs: Variant[] = [];
-      
+
       if (methodArgs) {
         for (const arg of methodArgs) {
           // Try to convert to appropriate type
           let convertedValue: any;
-          
+
           // Try float first
           const floatValue = parseFloat(arg);
           if (!isNaN(floatValue)) {
@@ -597,10 +616,10 @@ class OPCUAMCPServer {
               convertedValue = arg;
             }
           }
-          
-          convertedArgs.push(new Variant({ 
+
+          convertedArgs.push(new Variant({
             dataType: typeof convertedValue === 'number' ? DataType.Double : DataType.String,
-            value: convertedValue 
+            value: convertedValue
           }));
         }
       }
@@ -612,7 +631,7 @@ class OPCUAMCPServer {
       };
 
       const callResult: CallMethodResult = await this.session.call(methodToCall);
-      
+
       if (callResult.statusCode !== StatusCodes.Good) {
         throw new Error(`Method call failed with status: ${callResult.statusCode.toString()}`);
       }
@@ -647,11 +666,11 @@ class OPCUAMCPServer {
 
       // Start browsing from the Objects folder (ns=0;i=85)
       const objectsNodeId = "ns=0;i=85";
-      
+
       const searchVariables = async (nodeId: string): Promise<void> => {
         try {
           const browseResult = await this.session!.browse(nodeId);
-          
+
           if (browseResult.statusCode !== StatusCodes.Good || !browseResult.references) {
             return;
           }
@@ -660,7 +679,7 @@ class OPCUAMCPServer {
             try {
               const childNodeId = ref.nodeId.toString();
               const browseName = ref.browseName.name;
-              
+
               // Skip the entire "Server" subtree
               if (browseName === "Server") {
                 continue;
@@ -673,7 +692,7 @@ class OPCUAMCPServer {
               });
 
               const nodeClass = nodeClassResults.value?.value;
-              
+
               if (nodeClass === 2) { // NodeClass.Variable = 2
                 // This is a variable node
                 let value: any;
@@ -743,7 +762,7 @@ class OPCUAMCPServer {
           result += `  Data Type: ${variable.data_type}\n`;
           result += `  Description: ${variable.description}\n`;
         }
-        
+
         return {
           content: [
             {
@@ -776,4 +795,4 @@ class OPCUAMCPServer {
 
 // Run the server
 const server = new OPCUAMCPServer();
-server.run().catch(console.error); 
+server.run().catch(console.error);

--- a/opcua-mcp-npx-server/src/index.ts
+++ b/opcua-mcp-npx-server/src/index.ts
@@ -116,23 +116,137 @@ class OPCUAMCPServer {
 
   private setupToolHandlers() {
     this.server.setRequestHandler(ListToolsRequestSchema, async () => {
-      return {
-        tools: [
-          {
-            name: "read_opcua_node",
-            description: "Read the value of a specific OPC UA node",
-            inputSchema: {
-              type: "object",
-              properties: {
-                node_id: {
-                  type: "string",
-                  description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=2'."
-                }
+      let tools = [
+        {
+          name: "read_opcua_node",
+          description: "Read the value of a specific OPC UA node",
+          inputSchema: {
+            type: "object",
+            properties: {
+              node_id: {
+                type: "string",
+                description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=2'."
+              }
+            },
+            required: ["node_id"]
+          }
+        },
+        {
+          name: "write_opcua_node",
+          description: "Write a value to a specific OPC UA node",
+          inputSchema: {
+            type: "object",
+            properties: {
+              node_id: {
+                type: "string",
+                description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=3'."
               },
-              required: ["node_id"]
-            }
-          },
-          {
+              value: {
+                type: "string",
+                description: "The value to write to the node. Will be converted based on node type."
+              }
+            },
+            required: ["node_id", "value"]
+          }
+        },
+        {
+          name: "browse_opcua_node_children",
+          description: "Browse the children of a specific OPC UA node",
+          inputSchema: {
+            type: "object",
+            properties: {
+              node_id: {
+                type: "string",
+                description: "The OPC UA node ID to browse (e.g., 'ns=0;i=85' for Objects folder)."
+              }
+            },
+            required: ["node_id"]
+          }
+        },
+        {
+          name: "read_multiple_opcua_nodes",
+          description: "Read the values of multiple OPC UA nodes in a single request",
+          inputSchema: {
+            type: "object",
+            properties: {
+              node_ids: {
+                type: "array",
+                items: {
+                  type: "string"
+                },
+                description: "A list of OPC UA node IDs to read (e.g., ['ns=2;i=2', 'ns=2;i=3'])."
+              }
+            },
+            required: ["node_ids"]
+          }
+        },
+        {
+          name: "write_multiple_opcua_nodes",
+          description: "Write values to multiple OPC UA nodes in a single request",
+          inputSchema: {
+            type: "object",
+            properties: {
+              nodes_to_write: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    node_id: {
+                      type: "string"
+                    },
+                    value: {
+                      type: "string"
+                    }
+                  },
+                  required: ["node_id", "value"]
+                },
+                description: "A list of objects containing 'node_id' and 'value'. Example: [{'node_id': 'ns=2;i=2', 'value': '10.5'}, {'node_id': 'ns=2;i=3', 'value': 'active'}]"
+              }
+            },
+            required: ["nodes_to_write"]
+          }
+        },
+        {
+          name: "call_opcua_method",
+          description: "Call a method on a specific OPC UA object node",
+          inputSchema: {
+            type: "object",
+            properties: {
+              object_node_id: {
+                type: "string",
+                description: "The OPC UA node ID of the object that contains the method. Example: 'ns=2;i=1' for the Methods folder."
+              },
+              method_node_id: {
+                type: "string",
+                description: "The OPC UA node ID of the method to call. Example: 'ns=2;i=2' for StartProduction method."
+              },
+              arguments: {
+                type: "array",
+                items: {
+                  type: "string"
+                },
+                description: "List of arguments to pass to the method. Arguments will be converted to appropriate OPC UA variants."
+              }
+            },
+            required: ["object_node_id", "method_node_id"]
+          }
+        },
+        {
+          name: "get_all_variables",
+          description: "Get all available variables from the OPC UA server, excluding those under the built-in 'Server' object",
+          inputSchema: {
+            type: "object",
+            properties: {},
+            required: []
+          }
+        }
+      ] satisfies Tool[];
+
+      await this.ensureConnection();
+      if (this.session) {
+        const dataValue = await this.session.readVariableValue("ns=0;i=11193"); // AccessHistoryDataCapability
+        if (dataValue.statusCode === StatusCodes.Good && dataValue.value?.value === true) {
+          const t = {
             name: "read_history_opcua_node",
             description: "Read the historical values of a specific OPC UA node",
             inputSchema: {
@@ -155,118 +269,12 @@ class OPCUAMCPServer {
               },
               required: ["node_id"]
             }
-          },
-          {
-            name: "write_opcua_node",
-            description: "Write a value to a specific OPC UA node",
-            inputSchema: {
-              type: "object",
-              properties: {
-                node_id: {
-                  type: "string",
-                  description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=3'."
-                },
-                value: {
-                  type: "string",
-                  description: "The value to write to the node. Will be converted based on node type."
-                }
-              },
-              required: ["node_id", "value"]
-            }
-          },
-          {
-            name: "browse_opcua_node_children",
-            description: "Browse the children of a specific OPC UA node",
-            inputSchema: {
-              type: "object",
-              properties: {
-                node_id: {
-                  type: "string",
-                  description: "The OPC UA node ID to browse (e.g., 'ns=0;i=85' for Objects folder)."
-                }
-              },
-              required: ["node_id"]
-            }
-          },
-          {
-            name: "read_multiple_opcua_nodes",
-            description: "Read the values of multiple OPC UA nodes in a single request",
-            inputSchema: {
-              type: "object",
-              properties: {
-                node_ids: {
-                  type: "array",
-                  items: {
-                    type: "string"
-                  },
-                  description: "A list of OPC UA node IDs to read (e.g., ['ns=2;i=2', 'ns=2;i=3'])."
-                }
-              },
-              required: ["node_ids"]
-            }
-          },
-          {
-            name: "write_multiple_opcua_nodes",
-            description: "Write values to multiple OPC UA nodes in a single request",
-            inputSchema: {
-              type: "object",
-              properties: {
-                nodes_to_write: {
-                  type: "array",
-                  items: {
-                    type: "object",
-                    properties: {
-                      node_id: {
-                        type: "string"
-                      },
-                      value: {
-                        type: "string"
-                      }
-                    },
-                    required: ["node_id", "value"]
-                  },
-                  description: "A list of objects containing 'node_id' and 'value'. Example: [{'node_id': 'ns=2;i=2', 'value': '10.5'}, {'node_id': 'ns=2;i=3', 'value': 'active'}]"
-                }
-              },
-              required: ["nodes_to_write"]
-            }
-          },
-          {
-            name: "call_opcua_method",
-            description: "Call a method on a specific OPC UA object node",
-            inputSchema: {
-              type: "object",
-              properties: {
-                object_node_id: {
-                  type: "string",
-                  description: "The OPC UA node ID of the object that contains the method. Example: 'ns=2;i=1' for the Methods folder."
-                },
-                method_node_id: {
-                  type: "string",
-                  description: "The OPC UA node ID of the method to call. Example: 'ns=2;i=2' for StartProduction method."
-                },
-                arguments: {
-                  type: "array",
-                  items: {
-                    type: "string"
-                  },
-                  description: "List of arguments to pass to the method. Arguments will be converted to appropriate OPC UA variants."
-                }
-              },
-              required: ["object_node_id", "method_node_id"]
-            }
-          },
-          {
-            name: "get_all_variables",
-            description: "Get all available variables from the OPC UA server, excluding those under the built-in 'Server' object",
-            inputSchema: {
-              type: "object",
-              properties: {},
-              required: []
-            }
-          }
-        ] satisfies Tool[]
-      };
+          } satisfies Tool;
+          tools.push(t);
+        }
+      }
+
+      return { tools };
     });
 
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {

--- a/opcua-mcp-npx-server/src/index.ts
+++ b/opcua-mcp-npx-server/src/index.ts
@@ -149,11 +149,11 @@ class OPCUAMCPServer {
                   type: "datetime"
                 },
                 num_values: {
-                  type: "int",
+                  type: "number",
                   description: "Number of values to read (default: unlimited)"
                 },
               },
-              required: ["node_id", "starttime", "endtime"]
+              required: ["node_id"]
             }
           },
           {

--- a/opcua-mcp-npx-server/src/index.ts
+++ b/opcua-mcp-npx-server/src/index.ts
@@ -143,10 +143,10 @@ class OPCUAMCPServer {
                   description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=2'."
                 },
                 start_time: {
-                  type: "datetime"
+                  type: "string"
                 },
                 end_time: {
-                  type: "datetime"
+                  type: "string"
                 },
                 num_values: {
                   type: "number",

--- a/opcua-mcp-npx-server/src/index.ts
+++ b/opcua-mcp-npx-server/src/index.ts
@@ -367,10 +367,10 @@ class OPCUAMCPServer {
         numValuesPerNode
       });
       if (historyValues.length !== 1) {
-        throw new Error(`Read hisstory failed`);
+        throw new Error(`Read history failed`);
       }
       if (historyValues[0].statusCode !== StatusCodes.Good) {
-        throw new Error(`Read hisstory failed with status: ${historyValues[0].statusCode.toString()}`);
+        throw new Error(`Read history failed with status: ${historyValues[0].statusCode.toString()}`);
       }
       const dataValues = (historyValues[0].historyData as HistoryData).dataValues;
       return {

--- a/opcua-mcp-npx-server/src/index.ts
+++ b/opcua-mcp-npx-server/src/index.ts
@@ -38,7 +38,7 @@ class OPCUAMCPServer {
     this.server = new Server(
       {
         name: "opcua-mcp-npx-server",
-        version: "0.1.0",
+        version: "0.1.2",
       },
       {
         capabilities: {

--- a/opcua-mcp-server/README.md
+++ b/opcua-mcp-server/README.md
@@ -16,6 +16,7 @@ This MCP server acts as a bridge between AI assistants and OPC UA servers, allow
 ### Core Tools
 
 - **`read_opcua_node`** - Read the current value of any OPC UA node
+- **`history_read_opcua_node`** - Read the historical values of a specific OPC UA node
 - **`write_opcua_node`** - Write values to OPC UA nodes with automatic type conversion
 - **`browse_opcua_node_children`** - Explore the OPC UA address space and discover available nodes
 - **`call_opcua_method`** - Execute OPC UA methods on server objects
@@ -165,6 +166,12 @@ Result: Found 5 variables:
 ```python
 read_opcua_node(node_id="ns=2;i=3")
 # Returns: "Node ns=2;i=3 value: 26.57"
+```
+
+**Read multiple values from a single node:**
+```python
+history_read_opcua_node(node_id="ns=2;i=3", num_values=1)
+# Returns: [ { "value": "26.57", "timestamp": "2026-04-22 18:51:05.163834", "status": "Good" }]
 ```
 
 **Read multiple nodes:**

--- a/opcua-mcp-server/opcua-mcp-server.py
+++ b/opcua-mcp-server/opcua-mcp-server.py
@@ -5,6 +5,7 @@ from typing import AsyncIterator
 import asyncio
 import os
 from typing import List, Dict, Any
+from datetime import datetime
 from opcua import ua
 from opcua.ua import NodeClass
 
@@ -45,6 +46,41 @@ def read_opcua_node(node_id: str, ctx: Context) -> str:
     node = client.get_node(node_id)
     value = node.get_value()  # Synchronous call to get node value
     return f"Node {node_id} value: {value}"
+
+# Tool: Read historical values of an OPC UA node
+@mcp.tool()
+def history_read_opcua_node(node_id: str,
+                            ctx: Context,
+                            start_time: datetime | None = None,
+                            end_time: datetime | None = None,
+                            num_values: int = 0) -> [dict]:
+    """
+    Read the historical values of a specific OPC UA node.
+
+    Parameters:
+        node_id (str): The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'.
+                       Example: 'ns=2;i=2'.
+        start_time (datetime): Start time.
+                               Example: '2026-04-22 18:50:00'
+        end_time (datetime): End time.
+                             Example: '2026-04-22 18:51:00'
+        num_values (int): Number of values to read (default: unlimited)
+
+    Returns:
+        [dict]: An array of values `{ "value": <value>, "timestamp": <timestamp>, "status": "Good" }`
+    """
+    client = ctx.request_context.lifespan_context["opcua_client"]
+    node = client.get_node(node_id)
+    values = node.read_raw_history(starttime=start_time, endtime=end_time, numvalues=num_values)
+    return [
+        {
+            "value": str(v.Value.Value),
+            "timestamp": str(v.SourceTimestamp),
+            "status": str(v.StatusCode.name)
+        }
+        for v in values
+    ]
+
 
 # Tool: Write a value to an OPC UA node
 @mcp.tool()

--- a/opcua-mcp-server/pyproject.toml
+++ b/opcua-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opcua-mcp-server"
-version = "0.1.0"
+version = "0.1.2"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
1. If the server supports history data access, expose a `read_history_opcua_node` tool
2. If the server supports aggregate data access, expose a `read_aggregate_opcua_node` tool (only for the npx server)