### PR TITLE
Integrate history/aggregate reads (#1) with main + review fixes & E2E tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,115 @@
+# Contributing to OPC UA MCP
+
+Thanks for your interest in contributing! This repo provides **two MCP servers**
+(Python and TypeScript/npx) that bridge AI assistants to OPC UA servers, plus a
+**mock industrial OPC UA server** for local development and testing.
+
+- **[TESTING.md](TESTING.md)** — how to test (automated suite, MCP Inspector, AI agents)
+- **[EXAMPLES.md](EXAMPLES.md)** — per-tool inputs/outputs and node-ID reference
+
+## Repository layout
+
+| Path | What it is |
+|------|------------|
+| `opcua-local-server/` | Mock "Industrial Control System" OPC UA server (the simulated PLC/sensors) |
+| `opcua-mcp-server/` | **Python** MCP server (FastMCP + `opcua`/FreeOpcUa) |
+| `opcua-mcp-npx-server/` | **npx** MCP server (TypeScript + `@modelcontextprotocol/sdk` + `node-opcua`) |
+| `tests/` | End-to-end pytest suite driving both servers via the `mcp` SDK |
+| `EXAMPLES.md`, `TESTING.md` | Usage and testing docs |
+
+```
+AI assistant / MCP client  ──stdio──►  MCP server (Python OR npx)  ──OPC UA/TCP──►  mock server :4840
+```
+
+The two MCP servers are intended to **mirror each other**: a tool added to one
+should be added to the other with the **same name and arguments**.
+
+## Prerequisites
+
+- **Python 3.13+** and [`uv`](https://docs.astral.sh/uv/)
+- **Node.js 18+** and **npm**
+- No OPC UA broker needed — the mock server is included.
+
+## Local development
+
+Start the mock server first (it's the data source for everything else):
+
+```bash
+cd opcua-local-server && uv run main.py
+# listens on opc.tcp://0.0.0.0:4840/freeopcua/server/  (history enabled)
+```
+
+### Python MCP server
+```bash
+cd opcua-mcp-server
+uv sync
+OPCUA_SERVER_URL=opc.tcp://localhost:4840/freeopcua/server/ uv run opcua-mcp-server.py
+```
+
+### npx MCP server
+```bash
+cd opcua-mcp-npx-server
+npm install
+npm run build        # compiles src/index.ts -> build/index.js
+OPCUA_SERVER_URL=opc.tcp://localhost:4840/freeopcua/server/ node build/index.js
+```
+
+Both servers read the endpoint from `OPCUA_SERVER_URL` (default
+`opc.tcp://localhost:4840`). They speak MCP over **stdio**, so keep `stdout`
+clean — write all logs to `stderr`.
+
+## Running the tests
+
+```bash
+cd tests && uv run pytest -v        # 22 tests, both servers
+```
+
+See [tests/README.md](tests/README.md) for details and selectors
+(`-k python` / `-k npx`). For manual testing with the MCP Inspector or an AI
+agent, see **[TESTING.md](TESTING.md)**.
+
+## Adding a new MCP tool
+
+Keep the two servers in sync. To add a tool `foo`:
+
+1. **Python** (`opcua-mcp-server/opcua-mcp-server.py`): add a function decorated
+   with `@mcp.tool()`, typed args, a docstring, and `ctx: Context` to reach the
+   OPC UA client. Return a `str` or JSON-serialisable value.
+2. **npx** (`opcua-mcp-npx-server/src/index.ts`): add the tool to the
+   `ListToolsRequestSchema` handler (`name`, `description`, `inputSchema`), add a
+   `case` to the `CallToolRequestSchema` switch, and implement a private method.
+   Run `npm run build`.
+3. **Match names and arguments** across both servers.
+4. **Capability-gate** optional features. If a tool depends on a server
+   capability (as history/aggregate do), only advertise it when the capability is
+   present — see `read_history_opcua_node` (`AccessHistoryDataCapability`,
+   `ns=0;i=11193`) and `read_aggregate_opcua_node` (`AggregateFunctions`,
+   `ns=0;i=2997`).
+5. **Add an end-to-end test** in `tests/test_mcp_e2e.py` (it runs against both
+   servers automatically).
+6. **Document it** in the server READMEs and `EXAMPLES.md`.
+
+## Code style
+
+- **Python**: follow the surrounding style; type-hint tool signatures (FastMCP
+  derives the schema from them). Avoid `print()` to `stdout` — use
+  `print(..., file=sys.stderr)`.
+- **TypeScript**: `npm run build` must pass (`tsc`). Don't write to `stdout`
+  except via the MCP transport; the server already routes stray `console.log` to
+  `stderr`.
+- Convert/validate inputs explicitly (e.g. date strings → `Date`) and return
+  clear error messages.
+
+## Commit & PR conventions
+
+- Branch off `main`; keep commits focused with descriptive messages.
+- Run `cd tests && uv run pytest` before opening a PR.
+- Reference related issues/PRs (e.g. "Fixes #1").
+- If a change was AI-assisted, keep the `Co-Authored-By:` trailer.
+- PRs from forks: enable **"Allow edits by maintainers"** so reviewers can rebase.
+
+## Security note
+
+The servers connect with `SecurityPolicy.None` / `MessageSecurityMode.None` for
+local development. Do **not** use this configuration against production OPC UA
+systems — add certificate-based auth, encryption, and input validation first.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,0 +1,187 @@
+# OPC UA MCP — Tool Usage Examples
+
+Concrete, tested examples for every tool exposed by the Python and npx MCP
+servers, driven against the mock **Industrial Control System** OPC UA server.
+Outputs below are real (abbreviated) responses captured end-to-end.
+
+## Quick start
+
+```bash
+# 1) Start the mock OPC UA server (the simulated PLC/sensors)
+cd opcua-local-server && uv run main.py        # listens on opc.tcp://localhost:4840/freeopcua/server/
+
+# 2a) Python MCP server
+cd opcua-mcp-server && OPCUA_SERVER_URL=opc.tcp://localhost:4840/freeopcua/server/ uv run opcua-mcp-server.py
+
+# 2b) npx MCP server
+cd opcua-mcp-npx-server && npm install && npm run build
+OPCUA_SERVER_URL=opc.tcp://localhost:4840/freeopcua/server/ node build/index.js
+```
+
+Both read the endpoint from `OPCUA_SERVER_URL` (default `opc.tcp://localhost:4840`).
+
+## Node ID reference (mock server)
+
+Discover these any time with `get_all_variables` or `browse_opcua_node_children`.
+
+| Node | NodeId | Type | Access |
+|------|--------|------|--------|
+| Sensors / Temperature | `ns=2;i=3` | Double | read |
+| Sensors / Pressure | `ns=2;i=4` | Double | read |
+| Sensors / FlowRate | `ns=2;i=5` | Double | read |
+| Sensors / MotorSpeed | `ns=2;i=10` | Double | read |
+| Actuators / PumpEnabled | `ns=2;i=12` | Boolean | read/write |
+| Actuators / ValvePosition | `ns=2;i=13` | Double | read/write |
+| Actuators / HeaterPower | `ns=2;i=14` | Double | read/write |
+| SystemStatus / SystemMode | `ns=2;i=19` | String | read/write |
+| SystemStatus / ProductionRate | `ns=2;i=21` | Double | read |
+| SystemStatus / StartProductionCommand | `ns=2;i=23` | Double | write |
+| SystemStatus / StopProductionCommand | `ns=2;i=24` | Boolean | write |
+| Methods folder | `ns=2;i=27` | Object | — |
+| Methods / StartProduction | `ns=2;i=28` | Method | call (1 Double arg) |
+| Methods / StopProduction | `ns=2;i=31` | Method | call |
+| Methods / EmergencyStop | `ns=2;i=33` | Method | call |
+| Methods / ResetSystem | `ns=2;i=35` | Method | call |
+| Methods / CalibrateSensors | `ns=2;i=37` | Method | call (1 String arg) |
+
+> Method NodeIds account for the per-method `InputArguments`/`OutputArguments`
+> property nodes. Always browse the `Methods` folder rather than hard-coding.
+
+---
+
+## Core tools (both servers)
+
+### `read_opcua_node`
+Read one node's value.
+```json
+{ "node_id": "ns=2;i=3" }
+```
+```
+Node ns=2;i=3 value: 26.94
+```
+> Prompt: *"What is the current temperature?"*
+
+### `read_multiple_opcua_nodes`
+Batch read.
+```json
+{ "node_ids": ["ns=2;i=3", "ns=2;i=4", "ns=2;i=12"] }
+```
+```json
+{ "ns=2;i=3": 26.13, "ns=2;i=4": 1010.57, "ns=2;i=12": false }
+```
+> Prompt: *"Read temperature, pressure, and pump status together."*
+
+### `write_opcua_node`
+Write one node; the value is coerced to the node's data type.
+```json
+{ "node_id": "ns=2;i=13", "value": "80" }      // Double actuator
+{ "node_id": "ns=2;i=24", "value": "true" }     // Boolean command
+```
+```
+Successfully wrote 80 to node ns=2;i=13
+```
+> Note: the simulation republishes sensor/actuator state every ~1s, so direct
+> writes to those nodes are transient. Use the **command variables** or
+> **methods** to drive lasting state changes.
+> Prompt: *"Open valve V-101 to 80%."*
+
+### `write_multiple_opcua_nodes`
+Batch write.
+```json
+{ "nodes_to_write": [
+  { "node_id": "ns=2;i=13", "value": "80" },
+  { "node_id": "ns=2;i=14", "value": "30" }
+] }
+```
+```json
+[ { "node_id": "ns=2;i=13", "status": "Success" },
+  { "node_id": "ns=2;i=14", "status": "Success" } ]
+```
+
+### `browse_opcua_node_children`
+List a node's children.
+```json
+{ "node_id": "ns=2;i=1" }
+```
+```json
+[ { "node_id": "ns=2;i=2",  "browse_name": "2:Sensors" },
+  { "node_id": "ns=2;i=11", "browse_name": "2:Actuators" },
+  { "node_id": "ns=2;i=18", "browse_name": "2:SystemStatus" },
+  { "node_id": "ns=2;i=27", "browse_name": "2:Methods" } ]
+```
+> Prompt: *"What folders are under the Industrial Control System?"*
+
+### `call_opcua_method`
+Call a method on an object node.
+```json
+{ "object_node_id": "ns=2;i=27", "method_node_id": "ns=2;i=28", "arguments": ["60"] }
+```
+```
+Method call successful. Object: ns=2;i=27, Method: ns=2;i=28, Result: True
+```
+After this, `SystemMode` (`ns=2;i=19`) becomes `AUTO` and `ProductionRate`
+(`ns=2;i=21`) becomes `60` within ~1s.
+> Prompt: *"Start production at 60 units/hour, then stop it."*
+
+### `get_all_variables`
+Discover the whole address space (excludes the built-in `Server` subtree).
+```json
+{}
+```
+```
+Found 22 variables:
+- Name: Temperature   NodeID: ns=2;i=3   Value: 26.5   Data Type: ns=0;i=11
+- Name: PumpEnabled   NodeID: ns=2;i=12  Value: false  Data Type: ns=0;i=1
+...
+```
+> Prompt: *"Give me a complete inventory of everything on this server."*
+
+---
+
+## History & aggregate tools (added in PR #1)
+
+These are exposed **only when the server advertises the capability**. The mock
+server enables history (so the history tool appears) but advertises no aggregate
+functions (so the aggregate tool stays hidden).
+
+### `read_history_opcua_node` (both servers)
+Read recorded historical values for a node. Exposed only when the server
+advertises `AccessHistoryDataCapability`.
+
+Python:
+```json
+{ "node_id": "ns=2;i=3", "num_values": 3 }
+```
+```json
+[ { "value": "26.01", "timestamp": "2026-06-05 09:55:03.382152", "status": "Good" } ]
+```
+
+npx (also accepts ISO-8601 `start_time`/`end_time`):
+```json
+{ "node_id": "ns=2;i=3", "start_time": "2026-06-05T09:50:00Z",
+  "end_time": "2026-06-05T10:30:00Z", "num_values": 3 }
+```
+```json
+[ { "value": { "dataType": "Double", "value": 25 },
+    "statusCode": { "value": 0 },
+    "sourceTimestamp": "2026-06-05T09:53:40.950Z" } ]
+```
+> Prompt: *"Show the last 5 temperature readings from history."*
+
+### `read_aggregate_opcua_node` (npx only)
+Computes aggregates (Average, Minimum, Maximum, …) over a time range, one value
+per `processing_interval` (ms). **Requires a server that advertises aggregate
+functions** — the bundled mock does not, so this tool is not exposed against it.
+```json
+{ "node_id": "ns=2;i=3", "start_time": "2026-06-05T09:50:00Z",
+  "aggregate_function": "Average", "processing_interval": 60000 }
+```
+> Prompt: *"What was the average temperature per minute over the last hour?"*
+
+---
+
+## Tip
+
+You don't call these tools by hand in normal use — you ask Claude. The JSON above
+is what Claude sends under the hood. See `tests/` for an automated suite that
+exercises every tool against both servers.

--- a/README.md
+++ b/README.md
@@ -221,6 +221,26 @@ Both versions use the same environment variable:
 - `@types/node`: Node.js type definitions
 
 
+## Testing
+
+There are three ways to exercise the servers — the automated suite, the MCP
+Inspector (UI or CLI), and an AI agent (Claude Code / Desktop / Cursor). Start the
+mock server first, then:
+
+```bash
+cd tests && uv run pytest -v        # end-to-end suite, both servers
+```
+
+See **[TESTING.md](TESTING.md)** for the full guide (Inspector walkthrough, AI-agent
+setup, example prompts, troubleshooting) and **[EXAMPLES.md](EXAMPLES.md)** for
+per-tool inputs/outputs and a node-ID reference.
+
+## Contributing
+
+Contributions are welcome — see **[CONTRIBUTING.md](CONTRIBUTING.md)** for project
+layout, local development, adding a new tool to both servers, and PR conventions.
+
+
 ## Security
 
 Both versions currently connect with:

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,171 @@
+# Testing the OPC UA MCP Servers
+
+Three ways to test, from fully automated to fully interactive:
+
+1. [Automated end-to-end suite](#1-automated-end-to-end-suite) (`pytest`)
+2. [MCP Inspector](#2-mcp-inspector) — point-and-click or one-line CLI
+3. [AI agents](#3-ai-agents) — Claude Code, Claude Desktop, Cursor
+
+> **All three need the mock OPC UA server running first** — it is the simulated
+> device the MCP servers talk to.
+>
+> ```bash
+> cd opcua-local-server && uv run main.py
+> # opc.tcp://localhost:4840/freeopcua/server/  (history enabled on all variables)
+> ```
+>
+> Build the npx server once: `cd opcua-mcp-npx-server && npm install && npm run build`.
+
+A handy node-ID reference and per-tool examples live in [EXAMPLES.md](EXAMPLES.md).
+Common nodes: Temperature `ns=2;i=3`, PumpEnabled `ns=2;i=12`, ValvePosition
+`ns=2;i=13`, SystemMode `ns=2;i=19`, Methods folder `ns=2;i=27`, StartProduction
+`ns=2;i=28`.
+
+---
+
+## 1. Automated end-to-end suite
+
+Drives **both** servers over stdio with the official `mcp` client SDK and asserts
+on real responses. 22 tests (11 cases × Python + npx).
+
+```bash
+cd tests
+uv run pytest -v
+uv run pytest -v -k python     # only the Python server
+uv run pytest -v -k npx        # only the npx server
+```
+
+The suite reuses a mock server already on `:4840`, or starts its own. See
+[tests/README.md](tests/README.md) for the full matrix.
+
+---
+
+## 2. MCP Inspector
+
+[`@modelcontextprotocol/inspector`](https://github.com/modelcontextprotocol/inspector)
+is the standard tool for exercising an MCP server by hand.
+
+### UI mode (interactive)
+
+```bash
+# npx server
+OPCUA_SERVER_URL=opc.tcp://localhost:4840/freeopcua/server/ \
+  npx @modelcontextprotocol/inspector node opcua-mcp-npx-server/build/index.js
+
+# Python server
+cd opcua-mcp-server && OPCUA_SERVER_URL=opc.tcp://localhost:4840/freeopcua/server/ \
+  npx @modelcontextprotocol/inspector uv run opcua-mcp-server.py
+```
+
+It prints a `http://localhost:6274/?...` URL. In the browser:
+
+1. Click **Connect** (status should turn green).
+2. Open the **Tools** tab → **List Tools**.
+   - Seeing **`read_history_opcua_node`** confirms the server detected history
+     support on the mock and exposed the tool.
+3. Select a tool, fill the form, click **Run Tool**, read the result pane.
+
+Things to try:
+
+| Tool | Arguments | Expected |
+|------|-----------|----------|
+| `read_opcua_node` | `node_id` = `ns=2;i=3` | `Node ns=2;i=3 value: 26.x` |
+| `get_all_variables` | *(none)* | `Found 22 variables: …` |
+| `read_history_opcua_node` | `node_id` = `ns=2;i=3`, `num_values` = `5` | array of 5 timestamped records, status `Good` |
+| `read_history_opcua_node` | `node_id` = `ns=2;i=3`, `start_time` = `2026-01-01T00:00:00Z` | records within the window |
+| `read_history_opcua_node` | `node_id` = `ns=2;i=3`, `start_time` = `nope` | clear error: *Use ISO 8601…* |
+| `write_opcua_node` | `node_id` = `ns=2;i=13`, `value` = `80` | `Successfully wrote 80…` |
+| `call_opcua_method` | `object_node_id` = `ns=2;i=27`, `method_node_id` = `ns=2;i=28`, `arguments` = `["60"]` | `…Result: true` (SystemMode → AUTO within ~1s) |
+
+### CLI mode (scriptable, no browser)
+
+```bash
+URL=opc.tcp://localhost:4840/freeopcua/server/
+BIN="npx -y @modelcontextprotocol/inspector --cli node opcua-mcp-npx-server/build/index.js -e OPCUA_SERVER_URL=$URL"
+
+# list tools
+$BIN --method tools/list
+
+# read history (note: quote node IDs because ';' is a shell separator)
+$BIN --method tools/call --tool-name read_history_opcua_node \
+     --tool-arg 'node_id=ns=2;i=3' --tool-arg 'num_values=5'
+
+# call a method
+$BIN --method tools/call --tool-name call_opcua_method \
+     --tool-arg 'object_node_id=ns=2;i=27' --tool-arg 'method_node_id=ns=2;i=28' \
+     --tool-arg 'arguments=["60"]'
+```
+
+For the Python server, swap the command for
+`uv run opcua-mcp-server.py` (run from `opcua-mcp-server/`).
+
+---
+
+## 3. AI agents
+
+The end goal: an assistant calls these tools from natural language.
+
+### Claude Code
+
+Register both servers at **project scope** (writes `.mcp.json` in the repo root):
+
+```bash
+ROOT=$(pwd)
+URL=opc.tcp://localhost:4840/freeopcua/server/
+claude mcp add opcua-python -s project -e OPCUA_SERVER_URL=$URL \
+  -- uv --directory "$ROOT/opcua-mcp-server" run opcua-mcp-server.py
+claude mcp add opcua-npx -s project -e OPCUA_SERVER_URL=$URL \
+  -- node "$ROOT/opcua-mcp-npx-server/build/index.js"
+```
+
+Then, in a **new** Claude Code session started in this directory:
+
+1. Approve `opcua-python` / `opcua-npx` when prompted (project servers require
+   one-time approval). You can also manage them with the `/mcp` command.
+2. Run `/mcp` to confirm both are **connected** and list their tools.
+3. Ask away — example prompts:
+   - *"List the OPC UA tools you have available."*
+   - *"Read the current temperature from the OPC UA server."*
+   - *"Show me the last 5 temperature history readings."* → `read_history_opcua_node`
+   - *"Give me a full inventory of all variables on the server."*
+   - *"Start production at 60 units/hour, check the system mode, then stop it."*
+   - *"Use the opcua-npx server to read node ns=2;i=4 history between 11:00 and 12:00 UTC today."*
+
+> Both servers expose the same tool names (namespaced `opcua-python` /
+> `opcua-npx`); name a server in your prompt to target one specifically.
+
+### Claude Desktop
+
+Add to `claude_desktop_config.json`
+(`~/Library/Application Support/Claude/` on macOS) and restart the app:
+
+```json
+{
+  "mcpServers": {
+    "opcua-npx": {
+      "command": "node",
+      "args": ["/ABSOLUTE/PATH/OPCUA-MCP/opcua-mcp-npx-server/build/index.js"],
+      "env": { "OPCUA_SERVER_URL": "opc.tcp://localhost:4840/freeopcua/server/" }
+    }
+  }
+}
+```
+
+### Cursor
+
+Add the same `mcpServers` block to your Cursor MCP settings (Settings → MCP), then
+ask Cursor's assistant the prompts above.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---------|-------------|
+| **List Tools is empty or errors** | Mock server not running → `cd opcua-local-server && uv run main.py` |
+| **`read_history_opcua_node` not listed** | Connected to a server without history, or wrong `OPCUA_SERVER_URL` |
+| **`read_aggregate_opcua_node` not listed** | Expected — the bundled mock advertises no aggregate functions, so the tool is correctly hidden |
+| **`Address already in use` on :4840** | A mock server is already running; reuse it, or `lsof -tiTCP:4840 -sTCP:LISTEN \| xargs kill` |
+| **Project MCP servers `⏸ Pending approval`** | Normal — approve them in a new `claude` session or via `/mcp` |
+| **Values "snap back" after a write** | Expected — the mock republishes sensor/actuator state every ~1s; use command variables/methods for lasting changes |
+| **Node value lags after a method call** | The mock propagates method effects via its 1 Hz loop; re-read after ~1s |

--- a/opcua-local-server/client_example.py
+++ b/opcua-local-server/client_example.py
@@ -6,6 +6,7 @@ This demonstrates how to connect to and interact with the server.
 
 import time
 import logging
+from datetime import datetime, timedelta
 from opcua import Client, ua
 
 
@@ -48,8 +49,14 @@ def main():
                 sensor_node = sensors.get_child([f"2:{sensor_name}"])
                 value = sensor_node.get_value()
                 print(f"  {sensor_name}: {value:.2f}")
+
+                endtime = datetime.utcnow()
+                starttime = endtime - timedelta(hours=1)
+                history_data = sensor_node.read_raw_history(starttime, endtime, 5)
+                for history_data_value in history_data:
+                        print(f"  {sensor_name}: {history_data_value.Value.Value:.2f} @ {history_data_value.SourceTimestamp}")
             except Exception as e:
-                print(f"  Error reading {sensor_name}: {e}")
+                print(f"  ⚠️ Error reading {sensor_name}: {e}")
         
         # === CONTROLLING ACTUATORS ===
         print("\n⚙️ Controlling Actuators:")
@@ -99,7 +106,7 @@ def main():
             start_cmd_node.set_value(25.0)
             print(f"  Start production command sent: 25.0")
         except Exception as e:
-            print(f"  Error sending start production command: {e}")
+            print(f"  ⚠️ Error sending start production command: {e}")
         
         # Wait a moment for changes to take effect
         time.sleep(3)
@@ -119,7 +126,7 @@ def main():
                 value = sensor_node.get_value()
                 print(f"  {sensor_name}: {value:.2f}")
             except Exception as e:
-                print(f"  Error reading {sensor_name}: {e}")
+                print(f"  ⚠️ Error reading {sensor_name}: {e}")
         
         # Check pump status
         pump_node = actuators.get_child(["2:PumpEnabled"])
@@ -134,7 +141,7 @@ def main():
             stop_cmd_node.set_value(True)
             print(f"  Stop production command sent")
         except Exception as e:
-            print(f"  Error sending stop production command: {e}")
+            print(f"  ⚠️ Error sending stop production command: {e}")
         
         # Final status check
         time.sleep(2)
@@ -161,7 +168,7 @@ def main():
             print(f"  System Mode: {mode}")
             
         except Exception as e:
-            print(f"  Error testing emergency stop: {e}")
+            print(f"  ⚠️ Error testing emergency stop: {e}")
         
         # Reset system
         print("\n🔄 Resetting System:")
@@ -177,7 +184,7 @@ def main():
             print(f"  System Mode: {mode}")
             
         except Exception as e:
-            print(f"  Error resetting system: {e}")
+            print(f"  ⚠️ Error resetting system: {e}")
         
         print("\n✅ Demo completed successfully!")
         

--- a/opcua-local-server/client_example.py
+++ b/opcua-local-server/client_example.py
@@ -56,7 +56,7 @@ def main():
                 for history_data_value in history_data:
                         print(f"  {sensor_name}: {history_data_value.Value.Value:.2f} @ {history_data_value.SourceTimestamp}")
             except Exception as e:
-                print(f"  Error reading {sensor_name}: {e}")
+                print(f"  ⚠️ Error reading {sensor_name}: {e}")
         
         # === CONTROLLING ACTUATORS ===
         print("\n⚙️ Controlling Actuators:")
@@ -106,7 +106,7 @@ def main():
             start_cmd_node.set_value(25.0)
             print(f"  Start production command sent: 25.0")
         except Exception as e:
-            print(f"  Error sending start production command: {e}")
+            print(f"  ⚠️ Error sending start production command: {e}")
         
         # Wait a moment for changes to take effect
         time.sleep(3)
@@ -126,7 +126,7 @@ def main():
                 value = sensor_node.get_value()
                 print(f"  {sensor_name}: {value:.2f}")
             except Exception as e:
-                print(f"  Error reading {sensor_name}: {e}")
+                print(f"  ⚠️ Error reading {sensor_name}: {e}")
         
         # Check pump status
         pump_node = actuators.get_child(["2:PumpEnabled"])
@@ -141,7 +141,7 @@ def main():
             stop_cmd_node.set_value(True)
             print(f"  Stop production command sent")
         except Exception as e:
-            print(f"  Error sending stop production command: {e}")
+            print(f"  ⚠️ Error sending stop production command: {e}")
         
         # Final status check
         time.sleep(2)
@@ -168,7 +168,7 @@ def main():
             print(f"  System Mode: {mode}")
             
         except Exception as e:
-            print(f"  Error testing emergency stop: {e}")
+            print(f"  ⚠️ Error testing emergency stop: {e}")
         
         # Reset system
         print("\n🔄 Resetting System:")
@@ -184,7 +184,7 @@ def main():
             print(f"  System Mode: {mode}")
             
         except Exception as e:
-            print(f"  Error resetting system: {e}")
+            print(f"  ⚠️ Error resetting system: {e}")
         
         print("\n✅ Demo completed successfully!")
         

--- a/opcua-local-server/client_example.py
+++ b/opcua-local-server/client_example.py
@@ -6,6 +6,7 @@ This demonstrates how to connect to and interact with the server.
 
 import time
 import logging
+from datetime import datetime, timedelta
 from opcua import Client, ua
 
 
@@ -48,6 +49,12 @@ def main():
                 sensor_node = sensors.get_child([f"2:{sensor_name}"])
                 value = sensor_node.get_value()
                 print(f"  {sensor_name}: {value:.2f}")
+
+                endtime = datetime.utcnow()
+                starttime = endtime - timedelta(hours=1)
+                history_data = sensor_node.read_raw_history(starttime, endtime, 5)
+                for history_data_value in history_data:
+                        print(f"  {sensor_name}: {history_data_value.Value.Value:.2f} @ {history_data_value.SourceTimestamp}")
             except Exception as e:
                 print(f"  Error reading {sensor_name}: {e}")
         

--- a/opcua-local-server/opcua_local_server.py
+++ b/opcua-local-server/opcua_local_server.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import random
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Dict, Any
 
 from opcua import Server, ua
@@ -73,6 +73,19 @@ class IndustrialControlSystem:
         
         logging.info("Address space setup completed")
     
+    def historize(self):
+        accessHistoryDataCapability = self.server.get_node("ns=0;i=11193")
+        accessHistoryDataCapability.set_value(True)
+
+        objects = self.server.get_objects_node()
+        industrial_system = objects.get_child("2:IndustrialControlSystem")
+        for child in industrial_system.get_children():
+            for variable in child.get_variables():
+                logging.info(f"historize {child.get_display_name().to_string()};{variable.get_display_name().to_string()}")
+                self.server.historize_node_data_change(variable, period=timedelta(minutes=10), count=0)
+
+        logging.info("historize completed")
+
     def _create_sensor_variables(self, parent_folder: Node):
         """Create sensor variables with proper data types and descriptions."""
         
@@ -275,7 +288,7 @@ class IndustrialControlSystem:
             # Add some calibration effect
             pass
         return [ua.Variant(True, ua.VariantType.Boolean)]
-    
+
     def simulate_process(self):
         """Simulate industrial process behavior."""
         while self.running:
@@ -474,9 +487,10 @@ def main():
     try:
         # Setup the address space
         industrial_system.setup_address_space()
-        
+
         # Start the server
         server.start()
+        industrial_system.historize()
         logging.info("OPC UA Server started at opc.tcp://0.0.0.0:4840/freeopcua/server/")
         logging.info("Server is running and ready for connections")
         

--- a/opcua-local-server/opcua_local_server.py
+++ b/opcua-local-server/opcua_local_server.py
@@ -74,6 +74,9 @@ class IndustrialControlSystem:
         logging.info("Address space setup completed")
     
     def historize(self):
+        accessHistoryDataCapability = self.server.get_node("ns=0;i=11193")
+        accessHistoryDataCapability.set_value(True)
+
         objects = self.server.get_objects_node()
         industrial_system = objects.get_child("2:IndustrialControlSystem")
         for child in industrial_system.get_children():
@@ -477,7 +480,7 @@ def main():
     try:
         # Setup the address space
         industrial_system.setup_address_space()
-        
+
         # Start the server
         server.start()
         industrial_system.historize()

--- a/opcua-local-server/opcua_local_server.py
+++ b/opcua-local-server/opcua_local_server.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import random
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Dict, Any
 
 from opcua import Server, ua
@@ -73,6 +73,16 @@ class IndustrialControlSystem:
         
         logging.info("Address space setup completed")
     
+    def historize(self):
+        objects = self.server.get_objects_node()
+        industrial_system = objects.get_child("2:IndustrialControlSystem")
+        for child in industrial_system.get_children():
+            for variable in child.get_variables():
+                logging.info(f"historize {child.get_display_name().to_string()};{variable.get_display_name().to_string()}")
+                self.server.historize_node_data_change(variable, period=timedelta(minutes=10), count=0)
+
+        logging.info("historize completed")
+
     def _create_sensor_variables(self, parent_folder: Node):
         """Create sensor variables with proper data types and descriptions."""
         
@@ -268,7 +278,7 @@ class IndustrialControlSystem:
             # Add some calibration effect
             pass
         return True
-    
+
     def simulate_process(self):
         """Simulate industrial process behavior."""
         while self.running:
@@ -470,6 +480,7 @@ def main():
         
         # Start the server
         server.start()
+        industrial_system.historize()
         logging.info("OPC UA Server started at opc.tcp://0.0.0.0:4840/freeopcua/server/")
         logging.info("Server is running and ready for connections")
         

--- a/opcua-local-server/pyproject.toml
+++ b/opcua-local-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opcua-local-server"
-version = "0.1.0"
+version = "0.1.2"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/opcua-local-server/uv.lock
+++ b/opcua-local-server/uv.lock
@@ -40,7 +40,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/77/b1/5788cf02d4527ec81
 
 [[package]]
 name = "opcua-local-server"
-version = "0.1.0"
+version = "0.1.2"
 source = { virtual = "." }
 dependencies = [
     { name = "opcua" },

--- a/opcua-mcp-npx-server/README.md
+++ b/opcua-mcp-npx-server/README.md
@@ -12,6 +12,8 @@ An NPX-based Model Context Protocol (MCP) server for OPC UA operations. This ser
 - **Get All Variables**: Discover all available variables in the OPC UA server address space
 - **Automatic Type Conversion**: Intelligent conversion of values based on node data types
 - **Connection Management**: Automatic connection handling with graceful disconnection
+- **Read History OPC UA Node**: Read the historical values of a specific OPC UA node (if supported by the server)
+- **Read Aggregate OPC UA Node**: Calculate the historical aggregates (if supported by the server)
 
 ## Installation & Usage
 
@@ -66,6 +68,7 @@ Read the value of a specific OPC UA node.
   "node_id": "ns=2;i=1"
 }
 ```
+
 ### 2. write_opcua_node
 
 Write a value to a specific OPC UA node.
@@ -163,6 +166,47 @@ Get all available variables from the OPC UA server, excluding those under the bu
 
 **Returns:**
 A comprehensive list of all variables with their properties including name, node ID, object ID, current value, data type, and description.
+
+### 8. read_history_opcua_node
+
+Read the historical values of a specific OPC UA node.
+
+**Parameters:**
+- `node_id` (string): The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'
+- `start_time` (datetime)
+- `end_time` (datetime)
+- `num_values` (int): Number of values to read (default: unlimited)
+
+**Example:**
+```json
+{
+  "node_id": "ns=2;i=1",
+  "start_time": "2026-04-23 17:40:00",
+  "end_time": "2026-04-23 17:45:00"
+}
+```
+
+### 9. read_aggregate_opcua_node
+
+Calculate the historical aggregates over a defined time range, divided into smaller chunks defined by the `processing_interval` (in milliseconds). The server divides the [`start_time`, `end_time`] domain into these intervals, returning one aggregated value per interval.
+
+**Parameters:**
+- `node_id` (string): The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'
+- `start_time` (datetime): Beginning of the retrieval
+- `end_time` (datetime): End of the retrieval (defaults to 'now')
+- `aggregate_function` (string): The specific formula, e.g. Average, Minimum, Maximum
+- `processing_interval` (number): The duration (ms) for each computed value. If set to 0, the server calculates a single aggregate value for the entire range.
+
+**Example:**
+```json
+{
+  "node_id": "ns=2;i=1",
+  "start_time": "2026-04-23 17:40:00",
+  "end_time": "2026-04-23 17:45:00",
+  "aggregate_function": "Average",
+  "processing_interval": "60000"
+}
+```
 
 ## Integration with Cursor/Claude
 

--- a/opcua-mcp-npx-server/README.md
+++ b/opcua-mcp-npx-server/README.md
@@ -5,6 +5,7 @@ An NPX-based Model Context Protocol (MCP) server for OPC UA operations. This ser
 ## Features
 
 - **Read OPC UA Nodes**: Read values from individual or multiple OPC UA nodes
+- **Read History OPC UA Node**: Read the historical values of a specific OPC UA node
 - **Write OPC UA Nodes**: Write values to individual or multiple OPC UA nodes  
 - **Browse Node Children**: Explore the OPC UA address space by browsing node children
 - **Call OPC UA Methods**: Execute methods on OPC UA objects with parameters
@@ -66,7 +67,27 @@ Read the value of a specific OPC UA node.
   "node_id": "ns=2;i=1"
 }
 ```
-### 2. write_opcua_node
+
+### 2. read_history_opcua_node
+
+Read the historical values of a specific OPC UA node.
+
+**Parameters:**
+- `node_id` (string): The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'
+- `start_time` (datetime)
+- `end_time` (datetime)
+- `num_values` (int): Number of values to read (default: unlimited)
+
+**Example:**
+```json
+{
+  "node_id": "ns=2;i=1",
+  "start_time": "2026-04-23 17:40:00",
+  "end_time": "2026-04-23 17:45:00"
+}
+```
+
+### 3. write_opcua_node
 
 Write a value to a specific OPC UA node.
 
@@ -82,7 +103,7 @@ Write a value to a specific OPC UA node.
 }
 ```
 
-### 3. browse_opcua_node_children
+### 4. browse_opcua_node_children
 
 Browse the children of a specific OPC UA node.
 
@@ -96,7 +117,7 @@ Browse the children of a specific OPC UA node.
 }
 ```
 
-### 4. read_multiple_opcua_nodes
+### 5. read_multiple_opcua_nodes
 
 Read values from multiple OPC UA nodes in a single request.
 
@@ -114,7 +135,7 @@ Read values from multiple OPC UA nodes in a single request.
 }
 ```
 
-### 5. write_multiple_opcua_nodes
+### 6. write_multiple_opcua_nodes
 
 Write values to multiple OPC UA nodes in a single request.
 
@@ -131,7 +152,7 @@ Write values to multiple OPC UA nodes in a single request.
 }
 ```
 
-### 6. call_opcua_method
+### 7. call_opcua_method
 
 Call a method on a specific OPC UA object node.
 
@@ -149,7 +170,7 @@ Call a method on a specific OPC UA object node.
 }
 ```
 
-### 7. get_all_variables
+### 8. get_all_variables
 
 Get all available variables from the OPC UA server, excluding those under the built-in 'Server' object.
 

--- a/opcua-mcp-npx-server/README.md
+++ b/opcua-mcp-npx-server/README.md
@@ -5,7 +5,6 @@ An NPX-based Model Context Protocol (MCP) server for OPC UA operations. This ser
 ## Features
 
 - **Read OPC UA Nodes**: Read values from individual or multiple OPC UA nodes
-- **Read History OPC UA Node**: Read the historical values of a specific OPC UA node
 - **Write OPC UA Nodes**: Write values to individual or multiple OPC UA nodes  
 - **Browse Node Children**: Explore the OPC UA address space by browsing node children
 - **Call OPC UA Methods**: Execute methods on OPC UA objects with parameters
@@ -13,6 +12,8 @@ An NPX-based Model Context Protocol (MCP) server for OPC UA operations. This ser
 - **Get All Variables**: Discover all available variables in the OPC UA server address space
 - **Automatic Type Conversion**: Intelligent conversion of values based on node data types
 - **Connection Management**: Automatic connection handling with graceful disconnection
+- **Read History OPC UA Node**: Read the historical values of a specific OPC UA node (if supported by the server)
+- **Read Aggregate OPC UA Node**: Calculate the historical aggregates (if supported by the server)
 
 ## Installation & Usage
 
@@ -68,7 +69,105 @@ Read the value of a specific OPC UA node.
 }
 ```
 
-### 2. read_history_opcua_node
+### 2. write_opcua_node
+
+Write a value to a specific OPC UA node.
+
+**Parameters:**
+- `node_id` (string): The OPC UA node ID
+- `value` (string): The value to write (automatically converted to the correct type)
+
+**Example:**
+```json
+{
+  "node_id": "ns=2;i=2",
+  "value": "75.5"
+}
+```
+
+### 3. browse_opcua_node_children
+
+Browse the children of a specific OPC UA node.
+
+**Parameters:**
+- `node_id` (string): The OPC UA node ID to browse
+
+**Example:**
+```json
+{
+  "node_id": "ns=2;i=3"
+}
+```
+
+### 4. read_multiple_opcua_nodes
+
+Read values from multiple OPC UA nodes in a single request.
+
+**Parameters:**
+- `node_ids` (array): List of OPC UA node IDs to read
+
+**Example:**
+```json
+{
+  "node_ids": [
+    "ns=2;i=4", 
+    "ns=2;i=5", 
+    "ns=2;i=6"
+  ]
+}
+```
+
+### 5. write_multiple_opcua_nodes
+
+Write values to multiple OPC UA nodes in a single request.
+
+**Parameters:**
+- `nodes_to_write` (array): List of objects containing 'node_id' and 'value'
+
+**Example:**
+```json
+{
+  "nodes_to_write": [
+    {"node_id": "ns=2;i=7", "value": "50"},
+    {"node_id": "ns=2;i=8", "value": "true"}
+  ]
+}
+```
+
+### 6. call_opcua_method
+
+Call a method on a specific OPC UA object node.
+
+**Parameters:**
+- `object_node_id` (string): The OPC UA node ID of the object containing the method
+- `method_node_id` (string): The OPC UA node ID of the method to call
+- `arguments` (array, optional): List of arguments to pass to the method
+
+**Example:**
+```json
+{
+  "object_node_id": "ns=2;i=9",
+  "method_node_id": "ns=2;i=10",
+  "arguments": ["25.0", "high_quality"]
+}
+```
+
+### 7. get_all_variables
+
+Get all available variables from the OPC UA server, excluding those under the built-in 'Server' object.
+
+**Parameters:**
+- None required
+
+**Example:**
+```json
+{}
+```
+
+**Returns:**
+A comprehensive list of all variables with their properties including name, node ID, object ID, current value, data type, and description.
+
+### 8. read_history_opcua_node
 
 Read the historical values of a specific OPC UA node.
 
@@ -87,103 +186,27 @@ Read the historical values of a specific OPC UA node.
 }
 ```
 
-### 3. write_opcua_node
+### 9. read_aggregate_opcua_node
 
-Write a value to a specific OPC UA node.
+Calculate the historical aggregates over a defined time range, divided into smaller chunks defined by the `processing_interval` (in milliseconds). The server divides the [`start_time`, `end_time`] domain into these intervals, returning one aggregated value per interval.
 
 **Parameters:**
-- `node_id` (string): The OPC UA node ID
-- `value` (string): The value to write (automatically converted to the correct type)
+- `node_id` (string): The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'
+- `start_time` (datetime): Beginning of the retrieval
+- `end_time` (datetime): End of the retrieval (defaults to 'now')
+- `aggregate_function` (string): The specific formula, e.g. Average, Minimum, Maximum
+- `processing_interval` (number): The duration (ms) for each computed value. If set to 0, the server calculates a single aggregate value for the entire range.
 
 **Example:**
 ```json
 {
-  "node_id": "ns=2;i=2",
-  "value": "75.5"
+  "node_id": "ns=2;i=1",
+  "start_time": "2026-04-23 17:40:00",
+  "end_time": "2026-04-23 17:45:00",
+  "aggregate_function": "Average",
+  "processing_interval": "60000"
 }
 ```
-
-### 4. browse_opcua_node_children
-
-Browse the children of a specific OPC UA node.
-
-**Parameters:**
-- `node_id` (string): The OPC UA node ID to browse
-
-**Example:**
-```json
-{
-  "node_id": "ns=2;i=3"
-}
-```
-
-### 5. read_multiple_opcua_nodes
-
-Read values from multiple OPC UA nodes in a single request.
-
-**Parameters:**
-- `node_ids` (array): List of OPC UA node IDs to read
-
-**Example:**
-```json
-{
-  "node_ids": [
-    "ns=2;i=4", 
-    "ns=2;i=5", 
-    "ns=2;i=6"
-  ]
-}
-```
-
-### 6. write_multiple_opcua_nodes
-
-Write values to multiple OPC UA nodes in a single request.
-
-**Parameters:**
-- `nodes_to_write` (array): List of objects containing 'node_id' and 'value'
-
-**Example:**
-```json
-{
-  "nodes_to_write": [
-    {"node_id": "ns=2;i=7", "value": "50"},
-    {"node_id": "ns=2;i=8", "value": "true"}
-  ]
-}
-```
-
-### 7. call_opcua_method
-
-Call a method on a specific OPC UA object node.
-
-**Parameters:**
-- `object_node_id` (string): The OPC UA node ID of the object containing the method
-- `method_node_id` (string): The OPC UA node ID of the method to call
-- `arguments` (array, optional): List of arguments to pass to the method
-
-**Example:**
-```json
-{
-  "object_node_id": "ns=2;i=9",
-  "method_node_id": "ns=2;i=10",
-  "arguments": ["25.0", "high_quality"]
-}
-```
-
-### 8. get_all_variables
-
-Get all available variables from the OPC UA server, excluding those under the built-in 'Server' object.
-
-**Parameters:**
-- None required
-
-**Example:**
-```json
-{}
-```
-
-**Returns:**
-A comprehensive list of all variables with their properties including name, node ID, object ID, current value, data type, and description.
 
 ## Integration with Cursor/Claude
 

--- a/opcua-mcp-npx-server/package-lock.json
+++ b/opcua-mcp-npx-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opcua-mcp-npx-server",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opcua-mcp-npx-server",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/opcua-mcp-npx-server/package.json
+++ b/opcua-mcp-npx-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opcua-mcp-npx-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "NPX-based MCP server for OPC UA control - Model Context Protocol server for OPC UA operations",
   "main": "src/index.js",
   "type": "module",

--- a/opcua-mcp-npx-server/src/index.ts
+++ b/opcua-mcp-npx-server/src/index.ts
@@ -7,7 +7,7 @@ import {
   ListToolsRequestSchema,
   Tool,
 } from "@modelcontextprotocol/sdk/types.js";
-import { 
+import {
   OPCUAClient,
   MessageSecurityMode,
   SecurityPolicy,
@@ -19,22 +19,41 @@ import {
   StatusCodes,
   CallMethodResult,
   BrowseResult,
-  ReferenceDescription
+  ReferenceDescription,
+  HistoryData,
+  AggregateFunction,
 } from "node-opcua";
+
+// Keep stdout pristine for the MCP stdio JSON-RPC transport: route any stray
+// library logging (e.g. node-opcua PKI/certificate messages) to stderr.
+console.log = (...args: any[]) => console.error(...args);
 
 // OPC UA client configuration
 const SERVER_URL = process.env.OPCUA_SERVER_URL || "opc.tcp://localhost:4840";
+
+// Parse an optional ISO-8601 date/time string into a Date. MCP delivers these as
+// strings, so they must be converted before being handed to node-opcua.
+function toDate(value: string | Date | undefined): Date | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (value instanceof Date) return value;
+  const d = new Date(value);
+  if (isNaN(d.getTime())) {
+    throw new Error(`Invalid date/time: "${value}". Use ISO 8601, e.g. 2026-04-23T17:40:00Z`);
+  }
+  return d;
+}
 
 class OPCUAMCPServer {
   private server: Server;
   private opcuaClient: OPCUAClient | null = null;
   private session: ClientSession | null = null;
+  private aggregateFunctions: string[] = [];
 
   constructor() {
     this.server = new Server(
       {
         name: "opcua-mcp-npx-server",
-        version: "0.1.0",
+        version: "0.1.2",
       },
       {
         capabilities: {
@@ -112,135 +131,241 @@ class OPCUAMCPServer {
     }
   }
 
-  private setupToolHandlers() {
-    this.server.setRequestHandler(ListToolsRequestSchema, async () => {
-      return {
-        tools: [
-          {
-            name: "read_opcua_node",
-            description: "Read the value of a specific OPC UA node",
-            inputSchema: {
-              type: "object",
-              properties: {
-                node_id: {
-                  type: "string",
-                  description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=2'."
-                }
-              },
-              required: ["node_id"]
-            }
-          },
-          {
-            name: "write_opcua_node",
-            description: "Write a value to a specific OPC UA node",
-            inputSchema: {
-              type: "object",
-              properties: {
-                node_id: {
-                  type: "string",
-                  description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=3'."
-                },
-                value: {
-                  type: "string",
-                  description: "The value to write to the node. Will be converted based on node type."
-                }
-              },
-              required: ["node_id", "value"]
-            }
-          },
-          {
-            name: "browse_opcua_node_children",
-            description: "Browse the children of a specific OPC UA node",
-            inputSchema: {
-              type: "object",
-              properties: {
-                node_id: {
-                  type: "string",
-                  description: "The OPC UA node ID to browse (e.g., 'ns=0;i=85' for Objects folder)."
-                }
-              },
-              required: ["node_id"]
-            }
-          },
-          {
-            name: "read_multiple_opcua_nodes",
-            description: "Read the values of multiple OPC UA nodes in a single request",
-            inputSchema: {
-              type: "object",
-              properties: {
-                node_ids: {
-                  type: "array",
-                  items: {
-                    type: "string"
-                  },
-                  description: "A list of OPC UA node IDs to read (e.g., ['ns=2;i=2', 'ns=2;i=3'])."
-                }
-              },
-              required: ["node_ids"]
-            }
-          },
-          {
-            name: "write_multiple_opcua_nodes",
-            description: "Write values to multiple OPC UA nodes in a single request",
-            inputSchema: {
-              type: "object",
-              properties: {
-                nodes_to_write: {
-                  type: "array",
-                  items: {
-                    type: "object",
-                    properties: {
-                      node_id: {
-                        type: "string"
-                      },
-                      value: {
-                        type: "string"
-                      }
-                    },
-                    required: ["node_id", "value"]
-                  },
-                  description: "A list of objects containing 'node_id' and 'value'. Example: [{'node_id': 'ns=2;i=2', 'value': '10.5'}, {'node_id': 'ns=2;i=3', 'value': 'active'}]"
-                }
-              },
-              required: ["nodes_to_write"]
-            }
-          },
-          {
-            name: "call_opcua_method",
-            description: "Call a method on a specific OPC UA object node",
-            inputSchema: {
-              type: "object",
-              properties: {
-                object_node_id: {
-                  type: "string",
-                  description: "The OPC UA node ID of the object that contains the method. Example: 'ns=2;i=1' for the Methods folder."
-                },
-                method_node_id: {
-                  type: "string",
-                  description: "The OPC UA node ID of the method to call. Example: 'ns=2;i=2' for StartProduction method."
-                },
-                arguments: {
-                  type: "array",
-                  items: {
-                    type: "string"
-                  },
-                  description: "List of arguments to pass to the method. Arguments will be converted to appropriate OPC UA variants."
-                }
-              },
-              required: ["object_node_id", "method_node_id"]
-            }
-          },
-          {
-            name: "get_all_variables",
-            description: "Get all available variables from the OPC UA server, excluding those under the built-in 'Server' object",
-            inputSchema: {
-              type: "object",
-              properties: {},
-              required: []
+  private async accessHistoryDataCapability(): Promise<boolean> {
+    await this.ensureConnection();
+    const dataValue = await this.session!.readVariableValue("ns=0;i=11193"); // AccessHistoryDataCapability
+    return (
+      dataValue.statusCode === StatusCodes.Good &&
+      dataValue.value?.value === true
+    );
+  }
+
+  private async serverCapabilitiesAggregateFunctions(): Promise<string[]> {
+    await this.ensureConnection();
+    let aggregateFunctions: string[] = [];
+    try {
+      const browseResult = await this.session!.browse({
+        nodeId: "ns=0;i=2997", // AggregateFunctions
+        browseDirection: 0, // Forward
+        resultMask: 63, // All information (including BrowseName)
+      });
+      if (
+        browseResult.statusCode === StatusCodes.Good &&
+        browseResult.references
+      ) {
+        for (const reference of browseResult.references) {
+          // Map the string BrowseName to the AggregateFunction
+          if (reference.browseName.name) {
+            const name = reference.browseName.name.toString();
+            if (name in AggregateFunction) {
+              aggregateFunctions.push(name);
             }
           }
-        ] satisfies Tool[]
-      };
+        }
+      }
+    } catch (error) {
+      console.error(
+        "Error during serverCapabilitiesAggregateFunctions:",
+        error,
+      );
+    }
+    return aggregateFunctions;
+  }
+
+  private setupToolHandlers() {
+    this.server.setRequestHandler(ListToolsRequestSchema, async () => {
+      let tools = [
+        {
+          name: "read_opcua_node",
+          description: "Read the value of a specific OPC UA node",
+          inputSchema: {
+            type: "object",
+            properties: {
+              node_id: {
+                type: "string",
+                description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=2'."
+              }
+            },
+            required: ["node_id"]
+          }
+        },
+        {
+          name: "write_opcua_node",
+          description: "Write a value to a specific OPC UA node",
+          inputSchema: {
+            type: "object",
+            properties: {
+              node_id: {
+                type: "string",
+                description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=3'."
+              },
+              value: {
+                type: "string",
+                description: "The value to write to the node. Will be converted based on node type."
+              }
+            },
+            required: ["node_id", "value"]
+          }
+        },
+        {
+          name: "browse_opcua_node_children",
+          description: "Browse the children of a specific OPC UA node",
+          inputSchema: {
+            type: "object",
+            properties: {
+              node_id: {
+                type: "string",
+                description: "The OPC UA node ID to browse (e.g., 'ns=0;i=85' for Objects folder)."
+              }
+            },
+            required: ["node_id"]
+          }
+        },
+        {
+          name: "read_multiple_opcua_nodes",
+          description: "Read the values of multiple OPC UA nodes in a single request",
+          inputSchema: {
+            type: "object",
+            properties: {
+              node_ids: {
+                type: "array",
+                items: {
+                  type: "string"
+                },
+                description: "A list of OPC UA node IDs to read (e.g., ['ns=2;i=2', 'ns=2;i=3'])."
+              }
+            },
+            required: ["node_ids"]
+          }
+        },
+        {
+          name: "write_multiple_opcua_nodes",
+          description: "Write values to multiple OPC UA nodes in a single request",
+          inputSchema: {
+            type: "object",
+            properties: {
+              nodes_to_write: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    node_id: {
+                      type: "string"
+                    },
+                    value: {
+                      type: "string"
+                    }
+                  },
+                  required: ["node_id", "value"]
+                },
+                description: "A list of objects containing 'node_id' and 'value'. Example: [{'node_id': 'ns=2;i=2', 'value': '10.5'}, {'node_id': 'ns=2;i=3', 'value': 'active'}]"
+              }
+            },
+            required: ["nodes_to_write"]
+          }
+        },
+        {
+          name: "call_opcua_method",
+          description: "Call a method on a specific OPC UA object node",
+          inputSchema: {
+            type: "object",
+            properties: {
+              object_node_id: {
+                type: "string",
+                description: "The OPC UA node ID of the object that contains the method. Example: 'ns=2;i=1' for the Methods folder."
+              },
+              method_node_id: {
+                type: "string",
+                description: "The OPC UA node ID of the method to call. Example: 'ns=2;i=2' for StartProduction method."
+              },
+              arguments: {
+                type: "array",
+                items: {
+                  type: "string"
+                },
+                description: "List of arguments to pass to the method. Arguments will be converted to appropriate OPC UA variants."
+              }
+            },
+            required: ["object_node_id", "method_node_id"]
+          }
+        },
+        {
+          name: "get_all_variables",
+          description: "Get all available variables from the OPC UA server, excluding those under the built-in 'Server' object",
+          inputSchema: {
+            type: "object",
+            properties: {},
+            required: []
+          }
+        }
+      ] satisfies Tool[];
+
+      if (await this.accessHistoryDataCapability()) {
+        const t = {
+          name: "read_history_opcua_node",
+          description: "Read the historical values of a specific OPC UA node",
+          inputSchema: {
+            type: "object",
+            properties: {
+              node_id: {
+                type: "string",
+                description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=2'."
+              },
+              start_time: {
+                type: "string",
+                description: "Beginning of the retrieval"
+              },
+              end_time: {
+                type: "string",
+                description: "End of the retrieval"
+              },
+              num_values: {
+                type: "number",
+                description: "Number of values to read (default: unlimited)"
+              },
+            },
+            required: ["node_id"]
+          }
+        } satisfies Tool;
+        tools.push(t);
+      }
+
+      this.aggregateFunctions = await this.serverCapabilitiesAggregateFunctions();
+      if (this.aggregateFunctions.length > 0) {
+        const t = {
+          name: "read_aggregate_opcua_node",
+          description: "Calculate the historical aggregates over a defined time range, divided into smaller chunks defined by the `processing_interval` (in milliseconds). The server divides the [`start_time`, `end_time`] domain into these intervals, returning one aggregated value per interval",
+          inputSchema: {
+            type: "object",
+            properties: {
+              node_id: {
+                type: "string",
+                description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=2'."
+              },
+              start_time: {
+                type: "string",
+                description: "Beginning of the retrieval"
+              },
+              end_time: {
+                type: "string",
+                description: "End of the retrieval (defaults to 'now')"
+              },
+              aggregate_function: {
+                type: "string",
+                description: "The specific formula, one of: " + [...this.aggregateFunctions].join(", ")
+              },
+              processing_interval: {
+                type: "number",
+                description: "The duration (ms) for each computed value. If set to 0, the server calculates a single aggregate value for the entire range."
+              }
+            },
+            required: ["node_id", "start_time", "aggregate_function"]
+          }
+        } satisfies Tool;
+        tools.push(t);
+      }
+
+      return { tools };
     });
 
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
@@ -252,6 +377,23 @@ class OPCUAMCPServer {
         switch (name) {
           case "read_opcua_node":
             return await this.readOpcuaNode(args?.node_id as string);
+
+          case "read_history_opcua_node":
+            return await this.readHistoryOpcuaNode(
+              args?.node_id as string,
+              args?.start_time as string | undefined,
+              args?.end_time as string | undefined,
+              (args?.num_values as number) || 0,
+            );
+
+          case "read_aggregate_opcua_node":
+            return await this.readAggregateOpcuaNode(
+              args?.node_id as string,
+              args?.start_time as string,
+              args?.end_time as string | undefined,
+              args?.aggregate_function as string,
+              (args?.processing_interval as number) || 0,
+            );
 
           case "write_opcua_node":
             return await this.writeOpcuaNode(args?.node_id as string, args?.value as string);
@@ -298,7 +440,7 @@ class OPCUAMCPServer {
 
     try {
       const dataValue = await this.session.readVariableValue(nodeId);
-      
+
       if (dataValue.statusCode !== StatusCodes.Good) {
         throw new Error(`Read failed with status: ${dataValue.statusCode.toString()}`);
       }
@@ -317,6 +459,86 @@ class OPCUAMCPServer {
     }
   }
 
+  private async readHistoryOpcuaNode(
+    nodeId: string,
+    start: string | undefined,
+    end: string | undefined,
+    numValuesPerNode: number,
+  ) {
+    if (!this.session) {
+      throw new Error("No OPC UA session available");
+    }
+
+    try {
+      const historyValues = await this.session.readHistoryValue(
+        [nodeId],
+        toDate(start) as any,
+        toDate(end) as any,
+        {
+          numValuesPerNode,
+        },
+      );
+      if (historyValues.length !== 1) {
+        throw new Error(`Read history failed`);
+      }
+      if (historyValues[0].statusCode !== StatusCodes.Good) {
+        throw new Error(`Read history failed with status: ${historyValues[0].statusCode.toString()}`);
+      }
+      const dataValues = (historyValues[0].historyData as HistoryData).dataValues;
+      return {
+        content: [
+          {
+            type: "text",
+            text: `${JSON.stringify(dataValues, null, 2)}`
+          }
+        ]
+      };
+    } catch (error) {
+      throw new Error(`Failed to read node ${nodeId}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  private async readAggregateOpcuaNode(
+    nodeId: string,
+    start: string,
+    end: string | undefined,
+    aggregate_fn: string,
+    processing_interval: number,
+  ) {
+    if (!this.session) {
+      throw new Error("No OPC UA session available");
+    }
+
+    if (!this.aggregateFunctions.includes(aggregate_fn)) {
+      throw new Error("Invalid aggregate function");
+    }
+
+    try {
+      const aggregateFn = AggregateFunction[aggregate_fn as keyof typeof AggregateFunction];
+      const historyValues = await this.session.readAggregateValue(
+        { nodeId },
+        toDate(start) as any,
+        (toDate(end) ?? new Date()) as any,
+        aggregateFn,
+        processing_interval,
+      );
+      if (historyValues.statusCode !== StatusCodes.Good) {
+        throw new Error(`Read aggregate failed with status: ${historyValues.statusCode.toString()}`);
+      }
+      const dataValues = (historyValues.historyData as HistoryData).dataValues;
+      return {
+        content: [
+          {
+            type: "text",
+            text: `${JSON.stringify(dataValues, null, 2)}`
+          }
+        ]
+      };
+    } catch (error) {
+      throw new Error(`Failed to read node ${nodeId}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
   private async writeOpcuaNode(nodeId: string, value: string) {
     if (!this.session) {
       throw new Error("No OPC UA session available");
@@ -325,7 +547,7 @@ class OPCUAMCPServer {
     try {
       // First read the current value to determine the data type
       const currentDataValue = await this.session.readVariableValue(nodeId);
-      
+
       let convertedValue: any;
       const currentValue = currentDataValue.value?.value;
       // Coerce to string first: a client may send a non-string (e.g. boolean/number) value.
@@ -352,7 +574,7 @@ class OPCUAMCPServer {
       };
 
       const statusCode = await this.session.write(nodeToWrite);
-      
+
       if (statusCode !== StatusCodes.Good) {
         throw new Error(`Write failed with status: ${statusCode.toString()}`);
       }
@@ -377,7 +599,7 @@ class OPCUAMCPServer {
 
     try {
       const browseResult = await this.session.browse(nodeId);
-      
+
       if (browseResult.statusCode !== StatusCodes.Good) {
         throw new Error(`Browse failed with status: ${browseResult.statusCode.toString()}`);
       }
@@ -412,9 +634,9 @@ class OPCUAMCPServer {
       }));
 
       const dataValues = await this.session.read(nodesToRead);
-      
+
       const results: { [key: string]: any } = {};
-      
+
       dataValues.forEach((dataValue, index) => {
         const nodeId = nodeIds[index];
         if (dataValue.statusCode === StatusCodes.Good) {
@@ -451,11 +673,11 @@ class OPCUAMCPServer {
       }));
 
       const currentDataValues = await this.session.read(nodesToRead);
-      
+
       const writeNodes = nodesToWrite.map((item, index) => {
         const currentDataValue = currentDataValues[index];
         const currentValue = currentDataValue.value?.value;
-        
+
         let convertedValue: any;
         // Coerce to string first: a client may send a non-string (e.g. boolean/number) value.
         const valueStr = String(item.value);
@@ -476,16 +698,16 @@ class OPCUAMCPServer {
           nodeId: item.node_id,
           attributeId: AttributeIds.Value,
           value: new DataValue({
-            value: new Variant({ 
-              dataType: currentDataValue.value?.dataType || DataType.String, 
-              value: convertedValue 
+            value: new Variant({
+              dataType: currentDataValue.value?.dataType || DataType.String,
+              value: convertedValue
             })
           })
         };
       });
 
       const statusCodes = await this.session.write(writeNodes);
-      
+
       const results = statusCodes.map((statusCode, index) => ({
         node_id: nodesToWrite[index].node_id,
         status: statusCode === StatusCodes.Good ? 'Success' : `Error: ${statusCode.toString()}`
@@ -512,12 +734,12 @@ class OPCUAMCPServer {
     try {
       // Convert string arguments to appropriate types
       const convertedArgs: Variant[] = [];
-      
+
       if (methodArgs) {
         for (const arg of methodArgs) {
           // Try to convert to appropriate type
           let convertedValue: any;
-          
+
           // Try float first
           const floatValue = parseFloat(arg);
           if (!isNaN(floatValue)) {
@@ -532,10 +754,10 @@ class OPCUAMCPServer {
               convertedValue = arg;
             }
           }
-          
-          convertedArgs.push(new Variant({ 
+
+          convertedArgs.push(new Variant({
             dataType: typeof convertedValue === 'number' ? DataType.Double : DataType.String,
-            value: convertedValue 
+            value: convertedValue
           }));
         }
       }
@@ -547,7 +769,7 @@ class OPCUAMCPServer {
       };
 
       const callResult: CallMethodResult = await this.session.call(methodToCall);
-      
+
       if (callResult.statusCode !== StatusCodes.Good) {
         throw new Error(`Method call failed with status: ${callResult.statusCode.toString()}`);
       }
@@ -582,11 +804,11 @@ class OPCUAMCPServer {
 
       // Start browsing from the Objects folder (ns=0;i=85)
       const objectsNodeId = "ns=0;i=85";
-      
+
       const searchVariables = async (nodeId: string): Promise<void> => {
         try {
           const browseResult = await this.session!.browse(nodeId);
-          
+
           if (browseResult.statusCode !== StatusCodes.Good || !browseResult.references) {
             return;
           }
@@ -595,7 +817,7 @@ class OPCUAMCPServer {
             try {
               const childNodeId = ref.nodeId.toString();
               const browseName = ref.browseName.name;
-              
+
               // Skip the entire "Server" subtree
               if (browseName === "Server") {
                 continue;
@@ -608,7 +830,7 @@ class OPCUAMCPServer {
               });
 
               const nodeClass = nodeClassResults.value?.value;
-              
+
               if (nodeClass === 2) { // NodeClass.Variable = 2
                 // This is a variable node
                 let value: any;
@@ -678,7 +900,7 @@ class OPCUAMCPServer {
           result += `  Data Type: ${variable.data_type}\n`;
           result += `  Description: ${variable.description}\n`;
         }
-        
+
         return {
           content: [
             {
@@ -711,4 +933,4 @@ class OPCUAMCPServer {
 
 // Run the server
 const server = new OPCUAMCPServer();
-server.run().catch(console.error); 
+server.run().catch(console.error);

--- a/opcua-mcp-npx-server/src/index.ts
+++ b/opcua-mcp-npx-server/src/index.ts
@@ -132,18 +132,27 @@ class OPCUAMCPServer {
   }
 
   private async accessHistoryDataCapability(): Promise<boolean> {
-    await this.ensureConnection();
-    const dataValue = await this.session!.readVariableValue("ns=0;i=11193"); // AccessHistoryDataCapability
-    return (
-      dataValue.statusCode === StatusCodes.Good &&
-      dataValue.value?.value === true
-    );
+    // Best-effort: never let an optional capability probe break tools/list. A
+    // transient OPC UA outage should still leave the core tools advertised.
+    try {
+      await this.ensureConnection();
+      const dataValue = await this.session!.readVariableValue("ns=0;i=11193"); // AccessHistoryDataCapability
+      return (
+        dataValue.statusCode === StatusCodes.Good &&
+        dataValue.value?.value === true
+      );
+    } catch (error) {
+      console.error("accessHistoryDataCapability probe failed:", error);
+      return false;
+    }
   }
 
   private async serverCapabilitiesAggregateFunctions(): Promise<string[]> {
-    await this.ensureConnection();
+    // Best-effort: any failure (incl. a connection error) yields no aggregate
+    // functions rather than breaking tools/list.
     let aggregateFunctions: string[] = [];
     try {
+      await this.ensureConnection();
       const browseResult = await this.session!.browse({
         nodeId: "ns=0;i=2997", // AggregateFunctions
         browseDirection: 0, // Forward
@@ -509,8 +518,18 @@ class OPCUAMCPServer {
       throw new Error("No OPC UA session available");
     }
 
+    // Don't depend on a prior tools/list having populated the cache: a client may
+    // call this tool directly after connecting. Recompute on demand if empty.
+    if (this.aggregateFunctions.length === 0) {
+      this.aggregateFunctions = await this.serverCapabilitiesAggregateFunctions();
+    }
+
     if (!this.aggregateFunctions.includes(aggregate_fn)) {
-      throw new Error("Invalid aggregate function");
+      throw new Error(
+        this.aggregateFunctions.length === 0
+          ? "Server does not advertise any aggregate functions"
+          : `Invalid aggregate function. Supported: ${this.aggregateFunctions.join(", ")}`,
+      );
     }
 
     try {

--- a/opcua-mcp-npx-server/src/index.ts
+++ b/opcua-mcp-npx-server/src/index.ts
@@ -20,7 +20,8 @@ import {
   CallMethodResult,
   BrowseResult,
   ReferenceDescription,
-  HistoryData
+  HistoryData,
+  AggregateFunction,
 } from "node-opcua";
 import { DateTime } from "node-opcua-basic-types";
 
@@ -31,6 +32,7 @@ class OPCUAMCPServer {
   private server: Server;
   private opcuaClient: OPCUAClient | null = null;
   private session: ClientSession | null = null;
+  private aggregateFunctions: string[] = [];
 
   constructor() {
     this.server = new Server(
@@ -121,6 +123,38 @@ class OPCUAMCPServer {
       dataValue.statusCode === StatusCodes.Good &&
       dataValue.value?.value === true
     );
+  }
+
+  private async serverCapabilitiesAggregateFunctions(): Promise<string[]> {
+    await this.ensureConnection();
+    let aggregateFunctions: string[] = [];
+    try {
+      const browseResult = await this.session!.browse({
+        nodeId: "ns=0;i=2997", // AggregateFunctions
+        browseDirection: 0, // Forward
+        resultMask: 63, // All information (including BrowseName)
+      });
+      if (
+        browseResult.statusCode === StatusCodes.Good &&
+        browseResult.references
+      ) {
+        for (const reference of browseResult.references) {
+          // Map the string BrowseName to the AggregateFunction
+          if (reference.browseName.name) {
+            const name = reference.browseName.name.toString();
+            if (name in AggregateFunction) {
+              aggregateFunctions.push(name);
+            }
+          }
+        }
+      }
+    } catch (error) {
+      console.error(
+        "Error during serverCapabilitiesAggregateFunctions:",
+        error,
+      );
+    }
+    return aggregateFunctions;
   }
 
   private setupToolHandlers() {
@@ -281,6 +315,41 @@ class OPCUAMCPServer {
         tools.push(t);
       }
 
+      this.aggregateFunctions = await this.serverCapabilitiesAggregateFunctions();
+      if (this.aggregateFunctions.length > 0) {
+        const t = {
+          name: "read_aggregate_opcua_node",
+          description: "Calculate the historical aggregates over a defined time range, divided into smaller chunks defined by the `processing_interval` (in milliseconds). The server divides the [`start_time`, `end_time`] domain into these intervals, returning one aggregated value per interval",
+          inputSchema: {
+            type: "object",
+            properties: {
+              node_id: {
+                type: "string",
+                description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=2'."
+              },
+              start_time: {
+                type: "string",
+                description: "Beginning of the retrieval"
+              },
+              end_time: {
+                type: "string",
+                description: "End of the retrieval (defaults to 'now')"
+              },
+              aggregate_function: {
+                type: "string",
+                description: "The specific formula, one of: " + [...this.aggregateFunctions].join(", ")
+              },
+              processing_interval: {
+                type: "number",
+                description: "The duration (ms) for each computed value. If set to 0, the server calculates a single aggregate value for the entire range."
+              }
+            },
+            required: ["node_id", "start_time", "aggregate_function"]
+          }
+        } satisfies Tool;
+        tools.push(t);
+      }
+
       return { tools };
     });
 
@@ -300,6 +369,15 @@ class OPCUAMCPServer {
               args?.start_time as DateTime,
               args?.end_time as DateTime,
               (args?.num_values as number) || 0,
+            );
+
+          case "read_aggregate_opcua_node":
+            return await this.readAggregateOpcuaNode(
+              args?.node_id as string,
+              args?.start_time as DateTime,
+              (args?.end_time as DateTime) || new Date(),
+              args?.aggregate_function as string,
+              (args?.processing_interval as number) || 0,
             );
 
           case "write_opcua_node":
@@ -392,6 +470,47 @@ class OPCUAMCPServer {
         throw new Error(`Read history failed with status: ${historyValues[0].statusCode.toString()}`);
       }
       const dataValues = (historyValues[0].historyData as HistoryData).dataValues;
+      return {
+        content: [
+          {
+            type: "text",
+            text: `${JSON.stringify(dataValues, null, 2)}`
+          }
+        ]
+      };
+    } catch (error) {
+      throw new Error(`Failed to read node ${nodeId}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  private async readAggregateOpcuaNode(
+    nodeId: string,
+    start: DateTime,
+    end: DateTime,
+    aggregate_fn: string,
+    processing_interval: number,
+  ) {
+    if (!this.session) {
+      throw new Error("No OPC UA session available");
+    }
+
+    if (!this.aggregateFunctions.includes(aggregate_fn)) {
+      throw new Error("Invalid aggregate function");
+    }
+
+    try {
+      const aggregateFn = AggregateFunction[aggregate_fn as keyof typeof AggregateFunction];
+      const historyValues = await this.session.readAggregateValue(
+        { nodeId },
+        start,
+        end,
+        aggregateFn,
+        processing_interval,
+      );
+      if (historyValues.statusCode !== StatusCodes.Good) {
+        throw new Error(`Read aggregate failed with status: ${historyValues.statusCode.toString()}`);
+      }
+      const dataValues = (historyValues.historyData as HistoryData).dataValues;
       return {
         content: [
           {

--- a/opcua-mcp-npx-server/src/index.ts
+++ b/opcua-mcp-npx-server/src/index.ts
@@ -19,8 +19,10 @@ import {
   StatusCodes,
   CallMethodResult,
   BrowseResult,
-  ReferenceDescription
+  ReferenceDescription,
+  HistoryData
 } from "node-opcua";
+import { DateTime } from "node-opcua-basic-types";
 
 // OPC UA client configuration
 const SERVER_URL = process.env.OPCUA_SERVER_URL || "opc.tcp://localhost:4840";
@@ -128,6 +130,30 @@ class OPCUAMCPServer {
                 }
               },
               required: ["node_id"]
+            }
+          },
+          {
+            name: "read_history_opcua_node",
+            description: "Read the historical values of a specific OPC UA node",
+            inputSchema: {
+              type: "object",
+              properties: {
+                node_id: {
+                  type: "string",
+                  description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=2'."
+                },
+                start_time: {
+                  type: "datetime"
+                },
+                end_time: {
+                  type: "datetime"
+                },
+                num_values: {
+                  type: "int",
+                  description: "Number of values to read (default: unlimited)"
+                },
+              },
+              required: ["node_id", "starttime", "endtime"]
             }
           },
           {
@@ -253,6 +279,9 @@ class OPCUAMCPServer {
           case "read_opcua_node":
             return await this.readOpcuaNode(args?.node_id as string);
 
+          case "read_history_opcua_node":
+            return await this.readHistoryOpcuaNode(args?.node_id as string, args?.start_time as DateTime, args?.end_time as DateTime, (args?.num_values as number) || 0);
+
           case "write_opcua_node":
             return await this.writeOpcuaNode(args?.node_id as string, args?.value as string);
 
@@ -309,6 +338,38 @@ class OPCUAMCPServer {
           {
             type: "text",
             text: `Node ${nodeId} value: ${value}`
+          }
+        ]
+      };
+    } catch (error) {
+      throw new Error(`Failed to read node ${nodeId}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  private async readHistoryOpcuaNode(nodeId: string,
+                                     start: DateTime,
+                                     end: DateTime,
+                                     numValuesPerNode: number) {
+    if (!this.session) {
+      throw new Error("No OPC UA session available");
+    }
+
+    try {
+      const historyValues = await this.session.readHistoryValue([nodeId], start, end, {
+        numValuesPerNode
+      });
+      if (historyValues.length !== 1) {
+        throw new Error(`Read hisstory failed`);
+      }
+      if (historyValues[0].statusCode !== StatusCodes.Good) {
+        throw new Error(`Read hisstory failed with status: ${historyValues[0].statusCode.toString()}`);
+      }
+      const dataValues = (historyValues[0].historyData as HistoryData).dataValues;
+      return {
+        content: [
+          {
+            type: "text",
+            text: `${JSON.stringify(dataValues, null, 2)}`
           }
         ]
       };

--- a/opcua-mcp-npx-server/src/index.ts
+++ b/opcua-mcp-npx-server/src/index.ts
@@ -7,7 +7,7 @@ import {
   ListToolsRequestSchema,
   Tool,
 } from "@modelcontextprotocol/sdk/types.js";
-import { 
+import {
   OPCUAClient,
   MessageSecurityMode,
   SecurityPolicy,
@@ -112,6 +112,15 @@ class OPCUAMCPServer {
     if (!this.opcuaClient || !this.session) {
       await this.connect();
     }
+  }
+
+  private async accessHistoryDataCapability(): Promise<boolean> {
+    await this.ensureConnection();
+    const dataValue = await this.session!.readVariableValue("ns=0;i=11193"); // AccessHistoryDataCapability
+    return (
+      dataValue.statusCode === StatusCodes.Good &&
+      dataValue.value?.value === true
+    );
   }
 
   private setupToolHandlers() {
@@ -242,36 +251,34 @@ class OPCUAMCPServer {
         }
       ] satisfies Tool[];
 
-      await this.ensureConnection();
-      if (this.session) {
-        const dataValue = await this.session.readVariableValue("ns=0;i=11193"); // AccessHistoryDataCapability
-        if (dataValue.statusCode === StatusCodes.Good && dataValue.value?.value === true) {
-          const t = {
-            name: "read_history_opcua_node",
-            description: "Read the historical values of a specific OPC UA node",
-            inputSchema: {
-              type: "object",
-              properties: {
-                node_id: {
-                  type: "string",
-                  description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=2'."
-                },
-                start_time: {
-                  type: "string"
-                },
-                end_time: {
-                  type: "string"
-                },
-                num_values: {
-                  type: "number",
-                  description: "Number of values to read (default: unlimited)"
-                },
+      if (await this.accessHistoryDataCapability()) {
+        const t = {
+          name: "read_history_opcua_node",
+          description: "Read the historical values of a specific OPC UA node",
+          inputSchema: {
+            type: "object",
+            properties: {
+              node_id: {
+                type: "string",
+                description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=2'."
               },
-              required: ["node_id"]
-            }
-          } satisfies Tool;
-          tools.push(t);
-        }
+              start_time: {
+                type: "string",
+                description: "Beginning of the retrieval"
+              },
+              end_time: {
+                type: "string",
+                description: "End of the retrieval"
+              },
+              num_values: {
+                type: "number",
+                description: "Number of values to read (default: unlimited)"
+              },
+            },
+            required: ["node_id"]
+          }
+        } satisfies Tool;
+        tools.push(t);
       }
 
       return { tools };
@@ -288,7 +295,12 @@ class OPCUAMCPServer {
             return await this.readOpcuaNode(args?.node_id as string);
 
           case "read_history_opcua_node":
-            return await this.readHistoryOpcuaNode(args?.node_id as string, args?.start_time as DateTime, args?.end_time as DateTime, (args?.num_values as number) || 0);
+            return await this.readHistoryOpcuaNode(
+              args?.node_id as string,
+              args?.start_time as DateTime,
+              args?.end_time as DateTime,
+              (args?.num_values as number) || 0,
+            );
 
           case "write_opcua_node":
             return await this.writeOpcuaNode(args?.node_id as string, args?.value as string);
@@ -335,7 +347,7 @@ class OPCUAMCPServer {
 
     try {
       const dataValue = await this.session.readVariableValue(nodeId);
-      
+
       if (dataValue.statusCode !== StatusCodes.Good) {
         throw new Error(`Read failed with status: ${dataValue.statusCode.toString()}`);
       }
@@ -354,18 +366,25 @@ class OPCUAMCPServer {
     }
   }
 
-  private async readHistoryOpcuaNode(nodeId: string,
-                                     start: DateTime,
-                                     end: DateTime,
-                                     numValuesPerNode: number) {
+  private async readHistoryOpcuaNode(
+    nodeId: string,
+    start: DateTime,
+    end: DateTime,
+    numValuesPerNode: number,
+  ) {
     if (!this.session) {
       throw new Error("No OPC UA session available");
     }
 
     try {
-      const historyValues = await this.session.readHistoryValue([nodeId], start, end, {
-        numValuesPerNode
-      });
+      const historyValues = await this.session.readHistoryValue(
+        [nodeId],
+        start,
+        end,
+        {
+          numValuesPerNode,
+        },
+      );
       if (historyValues.length !== 1) {
         throw new Error(`Read history failed`);
       }
@@ -394,10 +413,10 @@ class OPCUAMCPServer {
     try {
       // First read the current value to determine the data type
       const currentDataValue = await this.session.readVariableValue(nodeId);
-      
+
       let convertedValue: any;
       const currentValue = currentDataValue.value?.value;
-      
+
       // Convert value based on the current type
       if (typeof currentValue === 'number') {
         convertedValue = parseFloat(value);
@@ -419,7 +438,7 @@ class OPCUAMCPServer {
       };
 
       const statusCode = await this.session.write(nodeToWrite);
-      
+
       if (statusCode !== StatusCodes.Good) {
         throw new Error(`Write failed with status: ${statusCode.toString()}`);
       }
@@ -444,7 +463,7 @@ class OPCUAMCPServer {
 
     try {
       const browseResult = await this.session.browse(nodeId);
-      
+
       if (browseResult.statusCode !== StatusCodes.Good) {
         throw new Error(`Browse failed with status: ${browseResult.statusCode.toString()}`);
       }
@@ -479,9 +498,9 @@ class OPCUAMCPServer {
       }));
 
       const dataValues = await this.session.read(nodesToRead);
-      
+
       const results: { [key: string]: any } = {};
-      
+
       dataValues.forEach((dataValue, index) => {
         const nodeId = nodeIds[index];
         if (dataValue.statusCode === StatusCodes.Good) {
@@ -518,13 +537,13 @@ class OPCUAMCPServer {
       }));
 
       const currentDataValues = await this.session.read(nodesToRead);
-      
+
       const writeNodes = nodesToWrite.map((item, index) => {
         const currentDataValue = currentDataValues[index];
         const currentValue = currentDataValue.value?.value;
-        
+
         let convertedValue: any;
-        
+
         // Convert value based on the current type
         if (typeof currentValue === 'number') {
           convertedValue = parseFloat(item.value);
@@ -541,16 +560,16 @@ class OPCUAMCPServer {
           nodeId: item.node_id,
           attributeId: AttributeIds.Value,
           value: new DataValue({
-            value: new Variant({ 
-              dataType: currentDataValue.value?.dataType || DataType.String, 
-              value: convertedValue 
+            value: new Variant({
+              dataType: currentDataValue.value?.dataType || DataType.String,
+              value: convertedValue
             })
           })
         };
       });
 
       const statusCodes = await this.session.write(writeNodes);
-      
+
       const results = statusCodes.map((statusCode, index) => ({
         node_id: nodesToWrite[index].node_id,
         status: statusCode === StatusCodes.Good ? 'Success' : `Error: ${statusCode.toString()}`
@@ -577,12 +596,12 @@ class OPCUAMCPServer {
     try {
       // Convert string arguments to appropriate types
       const convertedArgs: Variant[] = [];
-      
+
       if (methodArgs) {
         for (const arg of methodArgs) {
           // Try to convert to appropriate type
           let convertedValue: any;
-          
+
           // Try float first
           const floatValue = parseFloat(arg);
           if (!isNaN(floatValue)) {
@@ -597,10 +616,10 @@ class OPCUAMCPServer {
               convertedValue = arg;
             }
           }
-          
-          convertedArgs.push(new Variant({ 
+
+          convertedArgs.push(new Variant({
             dataType: typeof convertedValue === 'number' ? DataType.Double : DataType.String,
-            value: convertedValue 
+            value: convertedValue
           }));
         }
       }
@@ -612,7 +631,7 @@ class OPCUAMCPServer {
       };
 
       const callResult: CallMethodResult = await this.session.call(methodToCall);
-      
+
       if (callResult.statusCode !== StatusCodes.Good) {
         throw new Error(`Method call failed with status: ${callResult.statusCode.toString()}`);
       }
@@ -647,11 +666,11 @@ class OPCUAMCPServer {
 
       // Start browsing from the Objects folder (ns=0;i=85)
       const objectsNodeId = "ns=0;i=85";
-      
+
       const searchVariables = async (nodeId: string): Promise<void> => {
         try {
           const browseResult = await this.session!.browse(nodeId);
-          
+
           if (browseResult.statusCode !== StatusCodes.Good || !browseResult.references) {
             return;
           }
@@ -660,7 +679,7 @@ class OPCUAMCPServer {
             try {
               const childNodeId = ref.nodeId.toString();
               const browseName = ref.browseName.name;
-              
+
               // Skip the entire "Server" subtree
               if (browseName === "Server") {
                 continue;
@@ -673,7 +692,7 @@ class OPCUAMCPServer {
               });
 
               const nodeClass = nodeClassResults.value?.value;
-              
+
               if (nodeClass === 2) { // NodeClass.Variable = 2
                 // This is a variable node
                 let value: any;
@@ -743,7 +762,7 @@ class OPCUAMCPServer {
           result += `  Data Type: ${variable.data_type}\n`;
           result += `  Description: ${variable.description}\n`;
         }
-        
+
         return {
           content: [
             {
@@ -776,4 +795,4 @@ class OPCUAMCPServer {
 
 // Run the server
 const server = new OPCUAMCPServer();
-server.run().catch(console.error); 
+server.run().catch(console.error);

--- a/opcua-mcp-npx-server/src/index.ts
+++ b/opcua-mcp-npx-server/src/index.ts
@@ -116,23 +116,137 @@ class OPCUAMCPServer {
 
   private setupToolHandlers() {
     this.server.setRequestHandler(ListToolsRequestSchema, async () => {
-      return {
-        tools: [
-          {
-            name: "read_opcua_node",
-            description: "Read the value of a specific OPC UA node",
-            inputSchema: {
-              type: "object",
-              properties: {
-                node_id: {
-                  type: "string",
-                  description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=2'."
-                }
+      let tools = [
+        {
+          name: "read_opcua_node",
+          description: "Read the value of a specific OPC UA node",
+          inputSchema: {
+            type: "object",
+            properties: {
+              node_id: {
+                type: "string",
+                description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=2'."
+              }
+            },
+            required: ["node_id"]
+          }
+        },
+        {
+          name: "write_opcua_node",
+          description: "Write a value to a specific OPC UA node",
+          inputSchema: {
+            type: "object",
+            properties: {
+              node_id: {
+                type: "string",
+                description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=3'."
               },
-              required: ["node_id"]
-            }
-          },
-          {
+              value: {
+                type: "string",
+                description: "The value to write to the node. Will be converted based on node type."
+              }
+            },
+            required: ["node_id", "value"]
+          }
+        },
+        {
+          name: "browse_opcua_node_children",
+          description: "Browse the children of a specific OPC UA node",
+          inputSchema: {
+            type: "object",
+            properties: {
+              node_id: {
+                type: "string",
+                description: "The OPC UA node ID to browse (e.g., 'ns=0;i=85' for Objects folder)."
+              }
+            },
+            required: ["node_id"]
+          }
+        },
+        {
+          name: "read_multiple_opcua_nodes",
+          description: "Read the values of multiple OPC UA nodes in a single request",
+          inputSchema: {
+            type: "object",
+            properties: {
+              node_ids: {
+                type: "array",
+                items: {
+                  type: "string"
+                },
+                description: "A list of OPC UA node IDs to read (e.g., ['ns=2;i=2', 'ns=2;i=3'])."
+              }
+            },
+            required: ["node_ids"]
+          }
+        },
+        {
+          name: "write_multiple_opcua_nodes",
+          description: "Write values to multiple OPC UA nodes in a single request",
+          inputSchema: {
+            type: "object",
+            properties: {
+              nodes_to_write: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    node_id: {
+                      type: "string"
+                    },
+                    value: {
+                      type: "string"
+                    }
+                  },
+                  required: ["node_id", "value"]
+                },
+                description: "A list of objects containing 'node_id' and 'value'. Example: [{'node_id': 'ns=2;i=2', 'value': '10.5'}, {'node_id': 'ns=2;i=3', 'value': 'active'}]"
+              }
+            },
+            required: ["nodes_to_write"]
+          }
+        },
+        {
+          name: "call_opcua_method",
+          description: "Call a method on a specific OPC UA object node",
+          inputSchema: {
+            type: "object",
+            properties: {
+              object_node_id: {
+                type: "string",
+                description: "The OPC UA node ID of the object that contains the method. Example: 'ns=2;i=1' for the Methods folder."
+              },
+              method_node_id: {
+                type: "string",
+                description: "The OPC UA node ID of the method to call. Example: 'ns=2;i=2' for StartProduction method."
+              },
+              arguments: {
+                type: "array",
+                items: {
+                  type: "string"
+                },
+                description: "List of arguments to pass to the method. Arguments will be converted to appropriate OPC UA variants."
+              }
+            },
+            required: ["object_node_id", "method_node_id"]
+          }
+        },
+        {
+          name: "get_all_variables",
+          description: "Get all available variables from the OPC UA server, excluding those under the built-in 'Server' object",
+          inputSchema: {
+            type: "object",
+            properties: {},
+            required: []
+          }
+        }
+      ] satisfies Tool[];
+
+      await this.ensureConnection();
+      if (this.session) {
+        const dataValue = await this.session.readVariableValue("ns=0;i=11193"); // AccessHistoryDataCapability
+        if (dataValue.statusCode === StatusCodes.Good && dataValue.value?.value === true) {
+          const t = {
             name: "read_history_opcua_node",
             description: "Read the historical values of a specific OPC UA node",
             inputSchema: {
@@ -155,118 +269,12 @@ class OPCUAMCPServer {
               },
               required: ["node_id"]
             }
-          },
-          {
-            name: "write_opcua_node",
-            description: "Write a value to a specific OPC UA node",
-            inputSchema: {
-              type: "object",
-              properties: {
-                node_id: {
-                  type: "string",
-                  description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=3'."
-                },
-                value: {
-                  type: "string",
-                  description: "The value to write to the node. Will be converted based on node type."
-                }
-              },
-              required: ["node_id", "value"]
-            }
-          },
-          {
-            name: "browse_opcua_node_children",
-            description: "Browse the children of a specific OPC UA node",
-            inputSchema: {
-              type: "object",
-              properties: {
-                node_id: {
-                  type: "string",
-                  description: "The OPC UA node ID to browse (e.g., 'ns=0;i=85' for Objects folder)."
-                }
-              },
-              required: ["node_id"]
-            }
-          },
-          {
-            name: "read_multiple_opcua_nodes",
-            description: "Read the values of multiple OPC UA nodes in a single request",
-            inputSchema: {
-              type: "object",
-              properties: {
-                node_ids: {
-                  type: "array",
-                  items: {
-                    type: "string"
-                  },
-                  description: "A list of OPC UA node IDs to read (e.g., ['ns=2;i=2', 'ns=2;i=3'])."
-                }
-              },
-              required: ["node_ids"]
-            }
-          },
-          {
-            name: "write_multiple_opcua_nodes",
-            description: "Write values to multiple OPC UA nodes in a single request",
-            inputSchema: {
-              type: "object",
-              properties: {
-                nodes_to_write: {
-                  type: "array",
-                  items: {
-                    type: "object",
-                    properties: {
-                      node_id: {
-                        type: "string"
-                      },
-                      value: {
-                        type: "string"
-                      }
-                    },
-                    required: ["node_id", "value"]
-                  },
-                  description: "A list of objects containing 'node_id' and 'value'. Example: [{'node_id': 'ns=2;i=2', 'value': '10.5'}, {'node_id': 'ns=2;i=3', 'value': 'active'}]"
-                }
-              },
-              required: ["nodes_to_write"]
-            }
-          },
-          {
-            name: "call_opcua_method",
-            description: "Call a method on a specific OPC UA object node",
-            inputSchema: {
-              type: "object",
-              properties: {
-                object_node_id: {
-                  type: "string",
-                  description: "The OPC UA node ID of the object that contains the method. Example: 'ns=2;i=1' for the Methods folder."
-                },
-                method_node_id: {
-                  type: "string",
-                  description: "The OPC UA node ID of the method to call. Example: 'ns=2;i=2' for StartProduction method."
-                },
-                arguments: {
-                  type: "array",
-                  items: {
-                    type: "string"
-                  },
-                  description: "List of arguments to pass to the method. Arguments will be converted to appropriate OPC UA variants."
-                }
-              },
-              required: ["object_node_id", "method_node_id"]
-            }
-          },
-          {
-            name: "get_all_variables",
-            description: "Get all available variables from the OPC UA server, excluding those under the built-in 'Server' object",
-            inputSchema: {
-              type: "object",
-              properties: {},
-              required: []
-            }
-          }
-        ] satisfies Tool[]
-      };
+          } satisfies Tool;
+          tools.push(t);
+        }
+      }
+
+      return { tools };
     });
 
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {

--- a/opcua-mcp-npx-server/src/index.ts
+++ b/opcua-mcp-npx-server/src/index.ts
@@ -149,11 +149,11 @@ class OPCUAMCPServer {
                   type: "datetime"
                 },
                 num_values: {
-                  type: "int",
+                  type: "number",
                   description: "Number of values to read (default: unlimited)"
                 },
               },
-              required: ["node_id", "starttime", "endtime"]
+              required: ["node_id"]
             }
           },
           {

--- a/opcua-mcp-npx-server/src/index.ts
+++ b/opcua-mcp-npx-server/src/index.ts
@@ -143,10 +143,10 @@ class OPCUAMCPServer {
                   description: "The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'. Example: 'ns=2;i=2'."
                 },
                 start_time: {
-                  type: "datetime"
+                  type: "string"
                 },
                 end_time: {
-                  type: "datetime"
+                  type: "string"
                 },
                 num_values: {
                   type: "number",

--- a/opcua-mcp-npx-server/src/index.ts
+++ b/opcua-mcp-npx-server/src/index.ts
@@ -367,10 +367,10 @@ class OPCUAMCPServer {
         numValuesPerNode
       });
       if (historyValues.length !== 1) {
-        throw new Error(`Read hisstory failed`);
+        throw new Error(`Read history failed`);
       }
       if (historyValues[0].statusCode !== StatusCodes.Good) {
-        throw new Error(`Read hisstory failed with status: ${historyValues[0].statusCode.toString()}`);
+        throw new Error(`Read history failed with status: ${historyValues[0].statusCode.toString()}`);
       }
       const dataValues = (historyValues[0].historyData as HistoryData).dataValues;
       return {

--- a/opcua-mcp-npx-server/src/index.ts
+++ b/opcua-mcp-npx-server/src/index.ts
@@ -38,7 +38,7 @@ class OPCUAMCPServer {
     this.server = new Server(
       {
         name: "opcua-mcp-npx-server",
-        version: "0.1.0",
+        version: "0.1.2",
       },
       {
         capabilities: {

--- a/opcua-mcp-server/README.md
+++ b/opcua-mcp-server/README.md
@@ -16,6 +16,7 @@ This MCP server acts as a bridge between AI assistants and OPC UA servers, allow
 ### Core Tools
 
 - **`read_opcua_node`** - Read the current value of any OPC UA node
+- **`read_history_opcua_node`** - Read the historical values of a specific OPC UA node (only exposed if the server supports historical data access)
 - **`write_opcua_node`** - Write values to OPC UA nodes with automatic type conversion
 - **`browse_opcua_node_children`** - Explore the OPC UA address space and discover available nodes
 - **`call_opcua_method`** - Execute OPC UA methods on server objects
@@ -165,6 +166,12 @@ Result: Found 5 variables:
 ```python
 read_opcua_node(node_id="ns=2;i=3")
 # Returns: "Node ns=2;i=3 value: 26.57"
+```
+
+**Read historical values from a single node:**
+```python
+read_history_opcua_node(node_id="ns=2;i=3", num_values=1)
+# Returns: [ { "value": "26.57", "timestamp": "2026-04-22 18:51:05.163834", "status": "Good" }]
 ```
 
 **Read multiple nodes:**

--- a/opcua-mcp-server/README.md
+++ b/opcua-mcp-server/README.md
@@ -16,6 +16,7 @@ This MCP server acts as a bridge between AI assistants and OPC UA servers, allow
 ### Core Tools
 
 - **`read_opcua_node`** - Read the current value of any OPC UA node
+- **`history_read_opcua_node`** - Read the historical values of a specific OPC UA node
 - **`write_opcua_node`** - Write values to OPC UA nodes with automatic type conversion
 - **`browse_opcua_node_children`** - Explore the OPC UA address space and discover available nodes
 - **`call_opcua_method`** - Execute OPC UA methods on server objects
@@ -165,6 +166,12 @@ Result: Found 5 variables:
 ```python
 read_opcua_node(node_id="ns=2;i=3")
 # Returns: "Node ns=2;i=3 value: 26.57"
+```
+
+**Read multiple values from a single node:**
+```python
+history_read_opcua_node(node_id="ns=2;i=3", num_values=1)
+# Returns: [ { "value": "26.57", "timestamp": "2026-04-22 18:51:05.163834", "status": "Good" }]
 ```
 
 **Read multiple nodes:**

--- a/opcua-mcp-server/opcua-mcp-server.py
+++ b/opcua-mcp-server/opcua-mcp-server.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 import sys
 from typing import List, Dict, Any
+from datetime import datetime
 from opcua import ua
 from opcua.ua import NodeClass
 
@@ -47,6 +48,64 @@ def read_opcua_node(node_id: str, ctx: Context) -> str:
     node = client.get_node(node_id)
     value = node.get_value()  # Synchronous call to get node value
     return f"Node {node_id} value: {value}"
+
+# Tool: Read historical values of an OPC UA node.
+# Registered only when the server supports historical data access (see below),
+# mirroring the npx server's capability gating.
+def read_history_opcua_node(node_id: str,
+                            ctx: Context,
+                            start_time: datetime | None = None,
+                            end_time: datetime | None = None,
+                            num_values: int = 0) -> list[dict]:
+    """
+    Read the historical values of a specific OPC UA node.
+
+    Parameters:
+        node_id (str): The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'.
+                       Example: 'ns=2;i=2'.
+        start_time (datetime): Start time (ISO 8601).
+                               Example: '2026-04-22T18:50:00'
+        end_time (datetime): End time (ISO 8601).
+                             Example: '2026-04-22T18:51:00'
+        num_values (int): Number of values to read (default: unlimited)
+
+    Returns:
+        list[dict]: An array of values `{ "value": <value>, "timestamp": <timestamp>, "status": "Good" }`
+    """
+    client = ctx.request_context.lifespan_context["opcua_client"]
+    node = client.get_node(node_id)
+    values = node.read_raw_history(starttime=start_time, endtime=end_time, numvalues=num_values)
+    return [
+        {
+            "value": str(v.Value.Value),
+            "timestamp": str(v.SourceTimestamp),
+            "status": str(v.StatusCode.name)
+        }
+        for v in values
+    ]
+
+
+def _server_supports_history(url: str) -> bool:
+    """Probe the server's AccessHistoryDataCapability (ns=0;i=11193).
+
+    Used to expose `read_history_opcua_node` only when the server actually
+    supports historical reads, matching the npx server's behaviour.
+    """
+    try:
+        probe = Client(url)
+        probe.connect()
+        try:
+            return bool(probe.get_node("ns=0;i=11193").get_value())
+        finally:
+            probe.disconnect()
+    except Exception:
+        return False
+
+
+# Conditionally register the history tool based on server capability.
+if _server_supports_history(server_url):
+    read_history_opcua_node = mcp.tool()(read_history_opcua_node)
+
 
 # Tool: Write a value to an OPC UA node
 @mcp.tool()

--- a/opcua-mcp-server/opcua-mcp-server.py
+++ b/opcua-mcp-server/opcua-mcp-server.py
@@ -5,6 +5,7 @@ from typing import AsyncIterator
 import asyncio
 import os
 from typing import List, Dict, Any
+from datetime import datetime
 from opcua import ua
 from opcua.ua import NodeClass
 
@@ -45,6 +46,41 @@ def read_opcua_node(node_id: str, ctx: Context) -> str:
     node = client.get_node(node_id)
     value = node.get_value()  # Synchronous call to get node value
     return f"Node {node_id} value: {value}"
+
+# Tool: Read historical values of an OPC UA node
+@mcp.tool()
+def history_read_opcua_node(node_id: str,
+                            ctx: Context,
+                            start_time: datetime | None = None,
+                            end_time: datetime | None = None,
+                            num_values: int = 0) -> [dict]:
+    """
+    Read the historical values of a specific OPC UA node.
+
+    Parameters:
+        node_id (str): The OPC UA node ID in the format 'ns=<namespace>;i=<identifier>'.
+                       Example: 'ns=2;i=2'.
+        start_time (datetime): Start time.
+                               Example: '2026-04-22 18:50:00'
+        end_time (datetime): End time.
+                             Example: '2026-04-22 18:51:00'
+        num_values (int): Number of values to read (default: unlimited)
+
+    Returns:
+        [dict]: An array of values `{ "value": <value>, "timestamp": <timestamp>, "status": "Good" }`
+    """
+    client = ctx.request_context.lifespan_context["opcua_client"]
+    node = client.get_node(node_id)
+    values = node.read_raw_history(starttime=start_time, endtime=end_time, numvalues=num_values)
+    return [
+        {
+            "value": str(v.Value.Value),
+            "timestamp": str(v.SourceTimestamp),
+            "status": str(v.StatusCode.name)
+        }
+        for v in values
+    ]
+
 
 # Tool: Write a value to an OPC UA node
 @mcp.tool()

--- a/opcua-mcp-server/pyproject.toml
+++ b/opcua-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opcua-mcp-server"
-version = "0.1.0"
+version = "0.1.2"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/opcua-mcp-server/uv.lock
+++ b/opcua-mcp-server/uv.lock
@@ -251,7 +251,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/77/b1/5788cf02d4527ec81
 
 [[package]]
 name = "opcua-mcp-server"
-version = "0.1.0"
+version = "0.1.2"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+__pycache__/
+.pytest_cache/

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,61 @@
+# OPC UA MCP — End-to-End Test Suite
+
+Drives the **actual** MCP servers (Python and npx) over stdio with the official
+`mcp` client SDK, against the mock industrial OPC UA server. Every test runs
+against **both** server implementations.
+
+## What it covers
+
+| Test | What it verifies |
+|------|------------------|
+| `test_lists_core_tools` | All 7 core tools are advertised |
+| `test_history_tool_exposed_when_supported` | History tool appears because the mock enables history |
+| `test_aggregate_tool_hidden_when_unsupported` | Aggregate tool is **hidden** (mock advertises no aggregate functions) — capability gating |
+| `test_read_single_node` | `read_opcua_node` returns a value |
+| `test_read_multiple_nodes` | `read_multiple_opcua_nodes` returns all requested nodes |
+| `test_get_all_variables` | `get_all_variables` discovers the address space |
+| `test_browse_children` | `browse_opcua_node_children` lists the four folders |
+| `test_write_numeric_node` | Writing a `Double` actuator succeeds |
+| `test_write_boolean_node` | Writing a `Boolean` node with `"true"` succeeds (bool-handling regression) |
+| `test_call_method_start_then_stop` | `call_opcua_method` drives `StartProduction`/`StopProduction` and `SystemMode` reacts |
+| `test_read_history` | The history tool (`read_history_opcua_node`) returns timestamped records |
+
+Both servers expose the history tool under the same name, `read_history_opcua_node`,
+and only when the server advertises `AccessHistoryDataCapability`.
+
+## Prerequisites
+
+- `uv`, `node` (>=18), `npm`
+- Build the npx server once: `cd opcua-mcp-npx-server && npm install && npm run build`
+  (npx tests are **skipped** if `build/index.js` is missing).
+
+## Running
+
+```bash
+cd tests
+uv run pytest -v
+```
+
+The suite reuses a mock OPC UA server already listening on `:4840`; if none is
+running it starts one for the session (and waits a few seconds for history to
+accumulate). To force a specific endpoint:
+
+```bash
+OPCUA_SERVER_URL="opc.tcp://localhost:4840/freeopcua/server/" uv run pytest -v
+```
+
+Select a single implementation:
+
+```bash
+uv run pytest -v -k python
+uv run pytest -v -k npx
+```
+
+## Notes
+
+- The mock server's method callbacks update internal state; OPC UA node values
+  are propagated by its 1 Hz simulation loop, so tests poll (see
+  `wait_for_node_value`) rather than reading immediately after a method call.
+- Writes to sensor/actuator nodes may be overwritten within ~1s by the
+  simulation loop; only the command variables (`StartProductionCommand`, …) and
+  methods persist.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,72 @@
+"""Shared pytest fixtures for the OPC UA MCP end-to-end suite.
+
+The suite drives the *actual* MCP servers (Python and npx) over stdio using the
+official `mcp` client SDK, pointed at the mock industrial OPC UA server. A single
+session-scoped fixture makes sure a mock server is available: if one is already
+listening on :4840 it is reused, otherwise one is started for the test session.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+SERVER_URL = os.environ.get(
+    "OPCUA_SERVER_URL", "opc.tcp://localhost:4840/freeopcua/server/"
+)
+HOST = "localhost"
+PORT = 4840
+
+# Seconds of runtime to allow the mock server to accumulate history before tests
+# read it back. The mock writes one history record per variable per second.
+HISTORY_WARMUP_SECONDS = 6
+
+
+def _port_open(host: str, port: int, timeout: float = 0.5) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(timeout)
+        return sock.connect_ex((host, port)) == 0
+
+
+@pytest.fixture(scope="session")
+def opcua_server() -> str:
+    """Ensure a mock OPC UA server is reachable; reuse an existing one if present.
+
+    Yields the server endpoint URL.
+    """
+    if _port_open(HOST, PORT):
+        # Something is already serving on :4840 — assume it is the mock server.
+        yield SERVER_URL
+        return
+
+    proc = subprocess.Popen(
+        ["uv", "run", "main.py"],
+        cwd=ROOT / "opcua-local-server",
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.time() + 60
+        while time.time() < deadline:
+            if _port_open(HOST, PORT):
+                break
+            if proc.poll() is not None:
+                raise RuntimeError("mock OPC UA server exited during startup")
+            time.sleep(1)
+        else:
+            raise RuntimeError("mock OPC UA server did not start within 60s")
+
+        time.sleep(HISTORY_WARMUP_SECONDS)  # let some history build up
+        yield SERVER_URL
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "opcua-mcp-tests"
+version = "0.1.0"
+description = "End-to-end test suite for the OPC UA MCP servers (Python + npx)"
+requires-python = ">=3.13"
+dependencies = [
+    "mcp[cli]>=1.9.1",
+    "opcua>=0.98.13",
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+    "anyio>=4.0",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+addopts = "-ra"

--- a/tests/test_mcp_e2e.py
+++ b/tests/test_mcp_e2e.py
@@ -1,0 +1,296 @@
+"""End-to-end tests for the OPC UA MCP servers.
+
+Each test runs against BOTH the Python and the npx MCP server (parameterised via
+the ``mcp_session`` fixture), driving them over stdio with the official ``mcp``
+client SDK, against the mock industrial OPC UA server.
+
+Run:
+    cd tests && uv run pytest -v
+    # only one implementation:
+    cd tests && uv run pytest -v -k python
+    cd tests && uv run pytest -v -k npx
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from conftest import ROOT
+
+# --- Stable node IDs in the mock server's address space (namespace 2) ----------
+# Sensors / actuators / status keep fixed identifiers; method identifiers below
+# depend on the method argument nodes and are validated dynamically in the
+# call-method test rather than hard-trusted.
+NODE = {
+    "Temperature": "ns=2;i=3",
+    "Pressure": "ns=2;i=4",
+    "MotorSpeed": "ns=2;i=10",
+    "PumpEnabled": "ns=2;i=12",  # Boolean actuator
+    "ValvePosition": "ns=2;i=13",  # Double actuator
+    "SystemMode": "ns=2;i=19",
+    "ProductionRate": "ns=2;i=21",
+    "StartProductionCommand": "ns=2;i=23",  # Double command variable
+    "StopProductionCommand": "ns=2;i=24",  # Boolean command variable
+    "IndustrialControlSystem": "ns=2;i=1",
+    "Methods": "ns=2;i=27",
+}
+
+CORE_TOOLS = {
+    "read_opcua_node",
+    "write_opcua_node",
+    "browse_opcua_node_children",
+    "read_multiple_opcua_nodes",
+    "write_multiple_opcua_nodes",
+    "call_opcua_method",
+    "get_all_variables",
+}
+
+# Both implementations expose the history tool under the same name.
+HISTORY_TOOL = {
+    "python": "read_history_opcua_node",
+    "npx": "read_history_opcua_node",
+}
+
+NPX_BUILD = ROOT / "opcua-mcp-npx-server" / "build" / "index.js"
+
+
+def _server_params(impl: str, url: str) -> StdioServerParameters:
+    env = {**os.environ, "OPCUA_SERVER_URL": url}
+    if impl == "python":
+        return StdioServerParameters(
+            command="uv",
+            args=["--directory", str(ROOT / "opcua-mcp-server"), "run", "opcua-mcp-server.py"],
+            env=env,
+        )
+    if impl == "npx":
+        return StdioServerParameters(command="node", args=[str(NPX_BUILD)], env=env)
+    raise ValueError(impl)
+
+
+@pytest.fixture(params=["python", "npx"])
+def server(request, opcua_server):
+    """The ``(impl_name, StdioServerParameters)`` for each server implementation.
+
+    This is a *sync* fixture on purpose: the stdio/anyio client context is opened
+    and closed inside each test's own task (via ``connect`` below) so that anyio
+    cancel scopes are not entered and exited across different tasks.
+    """
+    impl = request.param
+    if impl == "npx" and not NPX_BUILD.exists():
+        pytest.skip("npx server not built — run `npm install && npm run build` in opcua-mcp-npx-server")
+    return impl, _server_params(impl, opcua_server)
+
+
+@asynccontextmanager
+async def connect(params: StdioServerParameters):
+    """Open an initialised MCP ClientSession over stdio."""
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            yield session
+
+
+# --- helpers -------------------------------------------------------------------
+
+def text_of(result) -> str:
+    """Concatenate all text content blocks of a CallToolResult."""
+    parts = []
+    for block in result.content:
+        text = getattr(block, "text", None)
+        if text is not None:
+            parts.append(text)
+    return "\n".join(parts)
+
+
+async def tool_names(session) -> set[str]:
+    res = await session.list_tools()
+    return {t.name for t in res.tools}
+
+
+async def wait_for_node_value(session, node_id: str, expected: str, attempts: int = 8, delay: float = 1.0) -> str:
+    """Poll a node until its value contains ``expected``.
+
+    The mock server's method callbacks mutate internal state; the OPC UA node
+    values are propagated by the 1 Hz simulation loop, so there is up to ~1s of
+    lag between calling a method and seeing the node change.
+    """
+    text = ""
+    for _ in range(attempts):
+        result = await session.call_tool("read_opcua_node", {"node_id": node_id})
+        text = text_of(result)
+        if expected in text:
+            return text
+        await asyncio.sleep(delay)
+    return text
+
+
+# --- tests ---------------------------------------------------------------------
+
+async def test_lists_core_tools(server):
+    impl, params = server
+    async with connect(params) as session:
+        names = await tool_names(session)
+    assert CORE_TOOLS <= names, f"{impl}: missing core tools: {CORE_TOOLS - names}"
+
+
+async def test_history_tool_exposed_when_supported(server):
+    """The mock server enables history, so each server should expose its history tool."""
+    impl, params = server
+    async with connect(params) as session:
+        names = await tool_names(session)
+    assert HISTORY_TOOL[impl] in names
+
+
+async def test_aggregate_tool_hidden_when_unsupported(server):
+    """The mock server advertises no aggregate functions, so the npx aggregate
+    tool must NOT be exposed (capability gating)."""
+    impl, params = server
+    async with connect(params) as session:
+        names = await tool_names(session)
+    assert "read_aggregate_opcua_node" not in names
+
+
+async def test_read_single_node(server):
+    impl, params = server
+    async with connect(params) as session:
+        result = await session.call_tool("read_opcua_node", {"node_id": NODE["Temperature"]})
+    assert not result.isError
+    text = text_of(result)
+    assert NODE["Temperature"] in text
+    assert "value" in text.lower()
+
+
+async def test_read_multiple_nodes(server):
+    impl, params = server
+    ids = [NODE["Temperature"], NODE["Pressure"], NODE["PumpEnabled"]]
+    async with connect(params) as session:
+        result = await session.call_tool("read_multiple_opcua_nodes", {"node_ids": ids})
+    assert not result.isError
+    text = text_of(result)
+    for nid in ids:
+        assert nid in text
+
+
+async def test_get_all_variables(server):
+    impl, params = server
+    async with connect(params) as session:
+        result = await session.call_tool("get_all_variables", {})
+    assert not result.isError
+    text = text_of(result)
+    assert "Found" in text and "variables" in text
+    assert "Temperature" in text
+
+
+async def test_browse_children(server):
+    impl, params = server
+    async with connect(params) as session:
+        result = await session.call_tool(
+            "browse_opcua_node_children", {"node_id": NODE["IndustrialControlSystem"]}
+        )
+    assert not result.isError
+    text = text_of(result)
+    for folder in ("Sensors", "Actuators", "SystemStatus", "Methods"):
+        assert folder in text
+
+
+async def test_write_numeric_node(server):
+    """Writing a Double actuator should succeed (the sim may overwrite it later)."""
+    impl, params = server
+    async with connect(params) as session:
+        result = await session.call_tool(
+            "write_opcua_node", {"node_id": NODE["ValvePosition"], "value": "80"}
+        )
+    assert not result.isError, text_of(result)
+    assert "Success" in text_of(result) or "wrote" in text_of(result).lower()
+
+
+async def test_write_boolean_node(server):
+    """Writing a Boolean node with 'true' must succeed (regression: bool handling)."""
+    impl, params = server
+    async with connect(params) as session:
+        result = await session.call_tool(
+            "write_opcua_node", {"node_id": NODE["StopProductionCommand"], "value": "true"}
+        )
+    assert not result.isError, text_of(result)
+    assert "Success" in text_of(result) or "wrote" in text_of(result).lower()
+
+
+async def test_call_method_start_then_stop(server):
+    """Drive production via the StartProduction / StopProduction methods and check
+    that SystemMode reacts. Exercises call_opcua_method + the method callbacks."""
+    impl, params = server
+    async with connect(params) as session:
+        methods = _discover_methods(await _browse_json(session, NODE["Methods"]))
+        assert "StartProduction" in methods and "StopProduction" in methods
+
+        start = await session.call_tool(
+            "call_opcua_method",
+            {
+                "object_node_id": NODE["Methods"],
+                "method_node_id": methods["StartProduction"],
+                "arguments": ["60"],
+            },
+        )
+        assert not start.isError, text_of(start)
+
+        mode = await wait_for_node_value(session, NODE["SystemMode"], "AUTO")
+        assert "AUTO" in mode
+
+        stop = await session.call_tool(
+            "call_opcua_method",
+            {"object_node_id": NODE["Methods"], "method_node_id": methods["StopProduction"]},
+        )
+        assert not stop.isError, text_of(stop)
+
+        mode2 = await wait_for_node_value(session, NODE["SystemMode"], "MANUAL")
+        assert "MANUAL" in mode2
+
+
+async def test_read_history(server):
+    """Read recent history for the Temperature sensor and assert we get records."""
+    impl, params = server
+    async with connect(params) as session:
+        result = await session.call_tool(
+            HISTORY_TOOL[impl], {"node_id": NODE["Temperature"], "num_values": 5}
+        )
+    assert not result.isError, text_of(result)
+    text = text_of(result)
+    # Both implementations surface a Good status and a timestamp per record.
+    assert "Good" in text or "sourceTimestamp" in text or "timestamp" in text
+    assert text.strip() not in ("", "[]")
+
+
+# --- browse parsing (server output formats differ) -----------------------------
+
+async def _browse_json(session, node_id: str):
+    """Return a list of {node_id, browse_name} dicts from a browse call.
+
+    The Python server emits a Python ``repr`` of the list while the npx server
+    emits JSON; this normalises both.
+    """
+    result = await session.call_tool("browse_opcua_node_children", {"node_id": node_id})
+    text = text_of(result)
+    blob = text[text.index("[") : text.rindex("]") + 1]
+    try:
+        return json.loads(blob)
+    except json.JSONDecodeError:
+        import ast
+
+        return ast.literal_eval(blob)
+
+
+def _discover_methods(children) -> dict[str, str]:
+    """Map method browse-name -> node_id from browse output."""
+    out = {}
+    for child in children:
+        name = str(child["browse_name"]).split(":")[-1]
+        out[name] = child["node_id"]
+    return out

--- a/tests/test_mcp_e2e.py
+++ b/tests/test_mcp_e2e.py
@@ -158,6 +158,28 @@ async def test_aggregate_tool_hidden_when_unsupported(server):
     assert "read_aggregate_opcua_node" not in names
 
 
+async def test_aggregate_direct_call_errors_cleanly(server):
+    """Calling read_aggregate_opcua_node directly (no prior tools/list) must not
+    crash or wrongly report 'Invalid aggregate function' due to an empty cache —
+    it should recompute support on demand and return a clear message. npx-only."""
+    impl, params = server
+    if impl != "npx":
+        pytest.skip("aggregate tool is npx-only")
+    async with connect(params) as session:
+        result = await session.call_tool(
+            "read_aggregate_opcua_node",
+            {
+                "node_id": NODE["Temperature"],
+                "start_time": "2026-01-01T00:00:00Z",
+                "aggregate_function": "Average",
+                "processing_interval": 60000,
+            },
+        )
+    # The mock advertises no aggregate functions, so we expect a clear,
+    # aggregate-related error rather than a crash or a misleading message.
+    assert "aggregate" in text_of(result).lower()
+
+
 async def test_read_single_node(server):
     impl, params = server
     async with connect(params) as session:

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -1,0 +1,838 @@
+version = 1
+revision = 2
+requires-python = ">=3.13"
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/eb/7e6f37c5584ccbb2ff267f56fd0339016938c1c8684cfefab9b33ffc2f36/lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736", size = 8559780, upload-time = "2026-05-18T19:17:57.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/36/587c2521cf23a2cd6c9c22108aa7528f683a1f195ed7ccd23a4b1786ad36/lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9", size = 4618006, upload-time = "2026-05-18T19:18:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ca/ab7bfe2bf4c972af5e7878262845ead3a24a929a9b04bc11c7c1ece6c82a/lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354", size = 4924139, upload-time = "2026-05-18T19:19:04.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/55/a0c72851dfee5ecc689f949723a73dea457758912542cb955b108eaf0d8f/lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca", size = 5082329, upload-time = "2026-05-18T19:19:09.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099", size = 4993564, upload-time = "2026-05-18T19:19:13.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/66/ae227524b066d29d55bf0b453d93d2d793c40218657d643dcbbca13b8faf/lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6", size = 5613467, upload-time = "2026-05-18T19:19:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/76/dbe4a00b50385e40194231dcfe5a12c059de7cf90e89c83407d2b085b719/lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085", size = 5228304, upload-time = "2026-05-18T19:19:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/00b1b8442ed2041793336868ba0b9ea4b13d7da7c085c6404c207a63bf79/lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e", size = 5341607, upload-time = "2026-05-18T19:19:22.297Z" },
+    { url = "https://files.pythonhosted.org/packages/63/36/1ad29931e9a4638bb707869f01d423a6c815f82152138d1a40dfcfde2b95/lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f", size = 4700168, upload-time = "2026-05-18T19:19:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/a9536cecf9be18a0dc72d32bead283a2332d1ffebd2dd3ac70ce444686e5/lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c", size = 5232487, upload-time = "2026-05-18T19:19:28.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/77/b4fb1e03bf5d130e879214d3100092e386418807fb74dd0adc4b0a48f351/lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b", size = 5044231, upload-time = "2026-05-18T19:18:42.246Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4c/d00daeeb0a5530c4028a9232aa1b93db3ef4ed2158c116ea73c79a9765b3/lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2", size = 4769450, upload-time = "2026-05-18T19:18:48.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6a/715a3a8d156ce42f29cf014706f5410c2ff3b02267774110fc23266409fe/lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5", size = 5635874, upload-time = "2026-05-18T19:18:51.914Z" },
+    { url = "https://files.pythonhosted.org/packages/45/37/0544bc21dde2a88f3a17b504e6fc79c0e01d25a33c2f6079724e9e72b9c7/lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785", size = 5223987, upload-time = "2026-05-18T19:18:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f8/f6a5e8185bcb28c2befae3d31f8e3df3b811cb0f47746517a81279fcafe1/lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947", size = 5250276, upload-time = "2026-05-18T19:19:03.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903, upload-time = "2026-05-18T19:17:29.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869, upload-time = "2026-05-18T19:18:02.596Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490, upload-time = "2026-05-19T19:22:53.846Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146, upload-time = "2026-05-18T19:18:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866, upload-time = "2026-05-18T19:18:30.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022, upload-time = "2026-05-18T19:19:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695, upload-time = "2026-05-18T19:19:34.764Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642, upload-time = "2026-05-18T19:19:37.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338, upload-time = "2026-05-18T19:19:40.553Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528, upload-time = "2026-05-18T19:19:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730, upload-time = "2026-05-18T19:19:46.307Z" },
+    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530, upload-time = "2026-05-18T19:19:49.889Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670, upload-time = "2026-05-18T19:19:53.199Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485, upload-time = "2026-05-18T19:19:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635, upload-time = "2026-05-18T19:19:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681, upload-time = "2026-05-18T19:19:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229, upload-time = "2026-05-18T19:19:18.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191, upload-time = "2026-05-18T19:19:21.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202, upload-time = "2026-05-18T19:17:39.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497, upload-time = "2026-05-18T19:18:14.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991, upload-time = "2026-05-19T19:22:59.111Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545, upload-time = "2026-05-18T19:18:41.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736, upload-time = "2026-05-18T19:18:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291, upload-time = "2026-05-18T19:19:56.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822, upload-time = "2026-05-18T19:19:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923, upload-time = "2026-05-18T19:20:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843, upload-time = "2026-05-18T19:20:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515, upload-time = "2026-05-18T19:20:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511, upload-time = "2026-05-18T19:20:09.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206, upload-time = "2026-05-18T19:20:11.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404, upload-time = "2026-05-18T19:20:14.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769, upload-time = "2026-05-18T19:19:23.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936, upload-time = "2026-05-18T19:19:27.256Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296, upload-time = "2026-05-18T19:19:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598, upload-time = "2026-05-18T19:19:33.523Z" },
+    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845, upload-time = "2026-05-18T19:19:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
+]
+
+[package.optional-dependencies]
+cli = [
+    { name = "python-dotenv" },
+    { name = "typer" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "opcua"
+version = "0.98.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/b1/5788cf02d4527ec816998ecd8b066242877f1b1ca6fcc07d7d4c0317fd04/opcua-0.98.13.tar.gz", hash = "sha256:3352f30b5fed863146a82778aaf09faa5feafcb9dd446a4f49ff34c0c3ebbde6", size = 572837, upload-time = "2021-03-03T10:40:31.607Z" }
+
+[[package]]
+name = "opcua-mcp-tests"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "anyio" },
+    { name = "mcp", extra = ["cli"] },
+    { name = "opcua" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anyio", specifier = ">=4.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.9.1" },
+    { name = "opcua", specifier = ">=0.98.13" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/32/14c961ad295f490eb0849ada8b79683e93a59b9de3afdd983eaf55fa6867/rpds_py-2026.5.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:efef4ac29c6ff495531eb17ee705b62841ecaa291b7c7077e848ea03e237164d", size = 352787, upload-time = "2026-05-28T11:59:33.655Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/bb/d1b85117967c11191441a7274ae616c65d93901d082c588f89a50a8da5ae/rpds_py-2026.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c39f5b67a8a2e67179ada2a954227d670fe65fa9098457f698f56ddf248709b3", size = 345179, upload-time = "2026-05-28T11:59:35Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/46/d84105f062e626a1b233f863907288a4708c2d833b8b4c6fb2764bc080c0/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5c30f3f04eef4fbd362226a6f31d7c8895ca4fbb6e0b790f6890a98d8da8559", size = 376173, upload-time = "2026-05-28T11:59:36.43Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/469d7959ce5b1201e1de135dc735b86db3b35dd0d1734f6a44246d5f061c/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:277f6c82f0580848796c7ecc8a7173aa3bfb928e4ff831261c2f60a81dc270db", size = 383162, upload-time = "2026-05-28T11:59:37.995Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/57853d31a1116a561aa072794602ad3f6341e18d70a8523f1bd5b9fc1e5a/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63c2c4c213f1a4e3f3de28ecab029dbdee976324e729c0d7a55211be72576b02", size = 495093, upload-time = "2026-05-28T11:59:39.453Z" },
+    { url = "https://files.pythonhosted.org/packages/99/63/3a8eabcad9314b7daf5c65f451d2c33d989235cd8a5762186cf2c3f5a4f8/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3350ec808fb538fe71a1f94dfaa0e29c598dfad805ce49f0caec5ae3183c652b", size = 389829, upload-time = "2026-05-28T11:59:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/05678d97fc25e2622df14dc530fb82023174ecfff6733991ed0d78f167bd/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1b964e3ab599e718dc46c018d104b1ebc007cbc6567d827c94a687fca56d77e", size = 374786, upload-time = "2026-05-28T11:59:42.626Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/8c90b6431e80a3b91b284a5c7c8c0c4f9c006444d90477a740d6e0f9c694/rpds_py-2026.5.1-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:19cb09fab7b7fc96b2a6e28f2e34b72a3705ff27b37edb77455316e5d3f3dc9b", size = 386920, upload-time = "2026-05-28T11:59:44.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/99/4638f672ab356682d633ee0da9255f5b67ce6efd0b85eb94ad3e255e65a5/rpds_py-2026.5.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:abe76bcdba31e576cb83eeb8797aa0d882b738fef6dc65d0601fc753806a5b46", size = 405059, upload-time = "2026-05-28T11:59:47.177Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3f/3546524b6eb4cc2e1f363a3d638fa52f6c24faae3500c25fb488b02f1740/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8bff7073db3899158fff55ebf57b113a67030af26f80a18978f9f0aa60250ddf", size = 553030, upload-time = "2026-05-28T11:59:48.603Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c3/7b3388c796fcf471bd17194242d4dc1a7608567c0fa422bcc1c5e79f9c1e/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8ba264fa49be666cd9cc56bf34ec7002fb3d27a4aee5bcb4d43d0d18feb1bb6f", size = 618975, upload-time = "2026-05-28T11:59:50.314Z" },
+    { url = "https://files.pythonhosted.org/packages/61/1e/a3cb07f2795075d1d88efddae2f541359fde5f08c81ee114c29c2949c90a/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4860b603ddda0475a8885499b3729e90229d480105b42651962a5397d995fa89", size = 581178, upload-time = "2026-05-28T11:59:51.673Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/74/e758c03a5ef46f04c37f2651a2893db846d569ba8a7bca469d4b58939bcd/rpds_py-2026.5.1-cp313-cp313-win32.whl", hash = "sha256:7944270ae71383f6e2657dd7d5ce4eeb4ac2d0059a6738f0510583d462ab4842", size = 212481, upload-time = "2026-05-28T11:59:53.148Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ec/a2aca432db9c7359b40fa393eeeaa0d166c2f70175be956e75fa24197c44/rpds_py-2026.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:88647f43a73c4e01be19b04ceef0c8d3a1958153604d13c773becd8016f2a0cf", size = 228519, upload-time = "2026-05-28T11:59:54.505Z" },
+    { url = "https://files.pythonhosted.org/packages/29/60/a73bfdd45b096574556acf303bbd9fa9eed36ca8a818b514e2a5d5fe2b9d/rpds_py-2026.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:453895624ecf7db7063b1004e44037522bbaef9ff6a945e59bc71662d7a03abd", size = 223446, upload-time = "2026-05-28T11:59:56.081Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e2/408105fd611823f00882aea810f3989a30d26b1bab8b6beb20f98c724e0e/rpds_py-2026.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:b4e4bc98639ec915f512fde3aa7a95e0041d95d9c3cc86eea841fa63cb1e8600", size = 355287, upload-time = "2026-05-28T11:59:57.448Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/58/5c4a43436843c90d0f6d19f82c200c80e3843ca9fa07b237623327f6d384/rpds_py-2026.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cacedb7a6e167680acba45ad5716e89067d225dc80da0d7040cae8c81d4572fa", size = 347033, upload-time = "2026-05-28T11:59:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c2/1a71acdacaf4e259b10278fb87b039ded3cf80041bcd89dd8a3ea702ded6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68700371c5d7ae1412862ddfa719090925c93ecf351c566d66f09d04b136ea00", size = 376891, upload-time = "2026-05-28T12:00:00.516Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c8/535f3d9b65addd8e28aa87b83c6e526799c3717a88273db8ea795beeef7a/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:296c799becfa849c779c8725494fe9ed94959ed886787df4364b058465bad7f0", size = 385646, upload-time = "2026-05-28T12:00:02.394Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/91/dc033f313345c354ade914dbe73cdb90b615a4409ea02430d5356794f3d8/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d3858b908218ee108d0bbfb2095ccc237648053c9bf98affad7cb079acaf1d97", size = 498830, upload-time = "2026-05-28T12:00:04.189Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fc/90fcbea459dbb8ddc18a2e0fd1de9412b48bc84ffff2db771cf714bacfd6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4fb8d2e7cb2f850b169806d61d1b991738acec96500a75c30f49caf064ce7cef", size = 392830, upload-time = "2026-05-28T12:00:05.797Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/46cd11a228c9750684a798d98f878be6f614aa762438da7378f035e79e35/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27b74c10ed6a8f190f4287f53bcfea348b92a84a9c9f70d30183d1e6172d580d", size = 379613, upload-time = "2026-05-28T12:00:07.433Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4a/d9b0c6af3a1de03eb93741bbe8be2bdce84d8fda8224f3005451d86df389/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:b9a6528956191c48c52294a592dbd4a8386d7048bdb25c0efcb6b966466c6d83", size = 388183, upload-time = "2026-05-28T12:00:09.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b4/db7aaabdda6d020afc87d981bcc2f57a434c7dec60ecfc2ab3dd50b20351/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:af03e34e860047bc7a352b842856fcf78798fbb81132cc98bd2f907ab4eb9cd2", size = 408578, upload-time = "2026-05-28T12:00:10.779Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d6/070f6a41cbb343e2ac4171859bf3f3623e0ab002f72619d6d505313ec2de/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fea6e836d10abbe191d557d33bd58bd5987725fe63aa1eefe557d230209855bd", size = 553573, upload-time = "2026-05-28T12:00:12.443Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ab/1a71ea3589c4345dac0a0518f0e6a031cb42689277851b683c46d27463a5/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:fc0c0f878ea770a0a8a462456c5ad36fc9fe6358e6b76fdadc7f17575e0b8bf1", size = 620861, upload-time = "2026-05-28T12:00:14.09Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/22/9bf80a56069c0c443fcfefac639a86a744550a2898817a6dfd3e26654924/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e0b360f316d966b048b085857630b3cc51f3db2f07b06f440eac8f695374d1e3", size = 585633, upload-time = "2026-05-28T12:00:15.66Z" },
+    { url = "https://files.pythonhosted.org/packages/da/68/3b2c0a75c9e04125696f84ebdbbf304acf5a40b58ba4481cdb98a922c3ba/rpds_py-2026.5.1-cp313-cp313t-win32.whl", hash = "sha256:a2999883eedf72fdfb7520b92c7d4ec2572a71ff40239377aa604cc529eecafc", size = 210074, upload-time = "2026-05-28T12:00:17.291Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8b/609157d5a25d37d4f29f92840ba531f416907c34ae5c5739dd21fc2bef98/rpds_py-2026.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e07be2a9d7122bd6e82dea89814ef8dc893feb1aae97fec1630f3263bbb30e55", size = 228635, upload-time = "2026-05-28T12:00:18.73Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6f/19c1918a4b590d8de87e712e4abe4b3875771eff60216fb6153cf6665c68/rpds_py-2026.5.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1f2c391c3059798093b65df23aca2cac150460ae9c630d99dec83d703d9485b9", size = 349756, upload-time = "2026-05-28T12:00:20.217Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/60/a06fe7da34eca79dacbf958a2ba0c6eea85bc2b29de20080bf40f72f66fa/rpds_py-2026.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:413b424f7c4ee65ab5e5be91f5731be0f8b41a1ee2b12dfe810d716312e95a78", size = 343831, upload-time = "2026-05-28T12:00:21.711Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ec/b2333b97b90e2a6ef6ca8ad386ee284968e74bcfe113b3f1a8d9036429a9/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c595a1d9255dce0599e13130d1440ab2506654f2b50294226ee06402f8fef63", size = 375127, upload-time = "2026-05-28T12:00:23.326Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7f/e00aae54067f2b488c4637961d5f58204d470795fc791085fa3f15060d2e/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1c27c5f6102eac8c03e7595a00827a53b271ba40a53b59ff8709170e0855ea4a", size = 379034, upload-time = "2026-05-28T12:00:24.89Z" },
+    { url = "https://files.pythonhosted.org/packages/be/cc/423999bbb8ae8dc93c77fc1d5e984ade5eb89d237d3bb884ccfa72ae2890/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c7fcf61d44cacecaf3aea542b0e053db77972a4573e7ceda16fb2b399161195", size = 490823, upload-time = "2026-05-28T12:00:26.676Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/aa/c671bf660f12e68d3c52ff86c7066ed1372df5a0f4f2ff584e419b8207e7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c817a189d4ee14290420e5ff051e4dd6baa13f3edf84685071dee07a6d538ee", size = 388144, upload-time = "2026-05-28T12:00:28.577Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c8/d63bb75b68afe77b229e3021c6031bcaf01da5db5b0e69d0d10f9ba679a7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21846aac0ed2e0589f38c12dc44e77bb64e494b771eadbcf169cba00566ba7ba", size = 371959, upload-time = "2026-05-28T12:00:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/c51122014d8274ff37dc606d60049c3db7d83da02b5b282511e5a906a9a6/rpds_py-2026.5.1-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b317c87a13f769a4e787819bd508aaa5d69aa09b0880de9af6d3a8a54571cdec", size = 383558, upload-time = "2026-05-28T12:00:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f9/2790cb99c136a5363acdeacf5c27c56f3de0d4118a1f48fca83404c99c89/rpds_py-2026.5.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ce87129d9f2c14fa6c4a8601fb80eb4488c80d38a20cd13758ef11123e14995d", size = 402789, upload-time = "2026-05-28T12:00:33.247Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1b/e4fb584f8c75d35c38150ff6a332cda949e6f97acba1f4fd123b14ab56fe/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9cdddb6c1207d284d94fd1530adf57fbd797fe7c4b8704ba85f49414f2557e7d", size = 551405, upload-time = "2026-05-28T12:00:34.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f7/a6731b4216cb3793ea1af5391da240f5683dacc0d13e034fe5fc3503f240/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:4e237e139f94d3c036fd28eb9f564c99055476ff4ff05cd42be55ce349b5aa02", size = 616975, upload-time = "2026-05-28T12:00:36.268Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/2e051a81d95d8e63f4b35a1c463a87e8766bc3d083c067c5dfb6bf220747/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ed0954b524873214369184a9c82b0eaa45a3fbb9a798cd95b17e0d98499e7ea0", size = 578701, upload-time = "2026-05-28T12:00:37.82Z" },
+    { url = "https://files.pythonhosted.org/packages/65/56/b5f6fdb2083e32bca8a8993d89e70db114b4756c9e2c38421328126689d2/rpds_py-2026.5.1-cp314-cp314-win32.whl", hash = "sha256:2d88621d6a7d4dfa633d21abe90f280bb205274e16b1d1e61c6ad4640b2453b7", size = 209806, upload-time = "2026-05-28T12:00:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/80/65a5aa96c155e611d1ed844e4e1f57f3e36b021f396d9f8585d756e6b90d/rpds_py-2026.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:cef8ac28d26f4dda3533060c20fbf80a325458fa9fd23ea72a73cdfa8e978838", size = 225985, upload-time = "2026-05-28T12:00:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7c/ad185212e87b05f196daef92bc5f3caf07298eb47c295b5585c3dd3093ac/rpds_py-2026.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:eaaea962c68cdc68d4a533ba985ab8e9484277910bbfaa2ab3ef7732667bfed8", size = 221219, upload-time = "2026-05-28T12:00:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/23/58/e14ae18759020334646b031e708ab4158d653a938822bfb7b95ef2e93aa3/rpds_py-2026.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:21942f52dbbd5f8758bf021213d28bd45c39e873e65e2407faf5f1846f5761ad", size = 352148, upload-time = "2026-05-28T12:00:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9b/5f4a1e2f960bca3ac5d052b139dd31eed97b259f9d909173821760d542e8/rpds_py-2026.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f414556f6e3958300ff941e40c9f97e3dc9774ddd1b3434c475d73dd354bbed3", size = 345196, upload-time = "2026-05-28T12:00:46.14Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/71/1d9574d6a2fa20ab60eaa55c7467f5aa20cbc770f341a05f09c0876f59e2/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef1013a8625c74043210190b246f5b1551e09757c1f356c6e4160ef96c5bc081", size = 374981, upload-time = "2026-05-28T12:00:47.531Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/37e99f4915a80aa71670263c1267f7ae0af95f53a3f61e6c3bdc016d4515/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cc68e231a77a5f0d774ae278a1f8e55c0456501820847c1e4efb3829f3441df6", size = 379961, upload-time = "2026-05-28T12:00:49.216Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ff/6e73f74b89d2e0715e0fc86b7dde893f9a61ae2f9b256ff3bdfe41ac4e94/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9baffb505aff33acc69b422a19f77806680f3c8632227d79f48de8a810d1c2c5", size = 495965, upload-time = "2026-05-28T12:00:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/e0/425faba25f59d74d4638b267f7c7a80e8649d2ef4db10a19b0c4a71e6e6f/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8d2f912928d426e8cfa396f7f3f8d29a59e6689c86dcca3c420730c1096322b", size = 389526, upload-time = "2026-05-28T12:00:52.77Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/76/7a41960e3fddae47fab43a28684d5da981401dffd88253de0944148654cb/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90f628283be835db980c941767d41c9a27b5239e54ba0a9c1335247e82406964", size = 376190, upload-time = "2026-05-28T12:00:54.215Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/5f38dc70824fc6951b51d35377e577a3a3a4c81a6769cc5a2de25ebe0ad1/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:1ebb2f0ab7e16132995a72de805170e0203df0c3dd22e1ef1cd1fdd90bd7a131", size = 383921, upload-time = "2026-05-28T12:00:55.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1a/d60a38caa1505f4b9483c3fbbde12c94e1079154f4f401a6da96f7e77621/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f3df3d16ded76f1f8c9cdebd0e1ea55fdf4c23b812de189814da7cf229c22a81", size = 404766, upload-time = "2026-05-28T12:00:57.518Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ff/602fd3f174d6425f0bce05ad0dfbec0e96b38d0f7d08a79af5aa20083885/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9af8905b8f854990e40d5206aa5ac58d9b0fe0b7f351ff2bb086c20f6c8c6a47", size = 551343, upload-time = "2026-05-28T12:00:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c1/1be13327acdbead3eca1fde03b6a34dbb011f1e864e217f0d32cc1779a7f/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:036a36a87fb1cd3b214d11c4b3c4f7d2ddad933625dca1c900b56a057c07740a", size = 618502, upload-time = "2026-05-28T12:01:00.656Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d7/afb49b49d7f2be8b7ba1a9f0977fa5168003437b93086726f066544e8351/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:62ae3853454fe9ef283a03c96c2d835d39e84b14643a9d62c82ef0fb87d702ca", size = 581916, upload-time = "2026-05-28T12:01:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d1/dbef8c1f8a10f07beb62b5f054e20099fd9924b3ec001b8f0b6ac7813a85/rpds_py-2026.5.1-cp314-cp314t-win32.whl", hash = "sha256:6c3d771a46ec18b12af06ce36243a9a80b07a5d0515236332d90863ca8bb326a", size = 207855, upload-time = "2026-05-28T12:01:03.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/72/bfa4e61ab8e7dc1c8adf397e05e6cbdd4239357bd72b248d3de662f23915/rpds_py-2026.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c93c629be4636cf54337bd5f06c104d55e42ced54d681f6fe21ae510a65116f6", size = 225422, upload-time = "2026-05-28T12:01:05.194Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/7b5da92b640f67b6717ccafc83cdd06bfa7ff2395c3685c68922bb54d703/rpds_py-2026.5.1-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:3574b55c604b8f75dacb007136508bbc0db406e626301778096a133327e7f2fb", size = 349576, upload-time = "2026-05-28T12:01:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8a/2aafd7ad355a1bd48ca76e2262b74b15e6432b5a1efe150efd4d779cd55d/rpds_py-2026.5.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:94068eb3ae6d43f5a786b7db96a406a34e6d5c24489feef32fd6e8946ea7b291", size = 343640, upload-time = "2026-05-28T12:01:08.441Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7d/6c9523c1abbe840a1b7fba3c516d48e1d3487cc80fea4366c4071cf56784/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a5b10e8ce894825f380a8f1b6444cf73c294dfea62afbb2d13e3a9e630cec1", size = 375322, upload-time = "2026-05-28T12:01:09.934Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5d/0b7b03fb1dc509321f01de3149784ab773e34c8573022029af8076afcb9c/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fc09f82e63d4bcd58149572f857a431bae851dc747e313c3b5bdf7abb907fda8", size = 379066, upload-time = "2026-05-28T12:01:11.48Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e2/8ef6012999ebf1cb1c22f876d9ce5e63d960fd4631d2af3202d3f480aa25/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e10464d17df3b582745c25cec695cb9558bca2cb6ddb631aee1787fc72c767b2", size = 494586, upload-time = "2026-05-28T12:01:13.051Z" },
+    { url = "https://files.pythonhosted.org/packages/80/af/1eeb029bec67582c226b7809172207cd005073af4ebd906e65ff494f4983/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba05adbf15d994c38ec0b7ab32e858e5110c21e9009a00a86545fd220f84e038", size = 388415, upload-time = "2026-05-28T12:01:14.631Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/ffbe10711c4d766c1cab0557d6906c074f795814863c67b351355d29354a/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77c004fdc7b891967106f78ddfd7b076bfe6813c6139c6fff6aed3bcaa960b26", size = 372427, upload-time = "2026-05-28T12:01:16.153Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3a/30ba4a6ad457e5b070c18d742a33fb77d8d922b565cc881f8a5313d63bfe/rpds_py-2026.5.1-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:83bcf894486c9d78dd290d3c0124ff6dd8875d3025e2090a8ec49fcc37c55fdd", size = 383615, upload-time = "2026-05-28T12:01:17.809Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/69/62e242b53ce39c0814bd24e1a6e6eba6c92be716277745f317f9540a2e7b/rpds_py-2026.5.1-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3df104083952a0e0c6f10de33e440eabe98fb6317d23e1a58c68f6df08d01b9", size = 402786, upload-time = "2026-05-28T12:01:19.419Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c1/a770b9c186928a1ed0f7e6d7ae50e7f3950ed23e3f9e366dbc8e38cb55de/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:980450826cf22e133c57e0835070bdd0dd3f73b9b708c3ce223def2cb9469e14", size = 551583, upload-time = "2026-05-28T12:01:21.013Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7c/68e8579b95375b70d2a963103c42e705856cdb98569258bd807f4423891c/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:205dde846f24332ab0c1188699a043b8d165b79bb84529ce272c45048ff6be01", size = 616941, upload-time = "2026-05-28T12:01:22.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a1/a6135aed5730ff03ab957182259987ac11e55fb392a28dc6f0592048a280/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:3966b82dd563176396df030f3dd52a6e54cb69b718e95e78bd555ed3d1e0185d", size = 578349, upload-time = "2026-05-28T12:01:24.118Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6e/f24201a76a84e6c49d0bdfdfcb735210e21701e9b21c5bfc0ba497dd62f6/rpds_py-2026.5.1-cp315-cp315-win32.whl", hash = "sha256:7818f8d0a415be74d2be3590b0a1c1f463a642f4d0217e7d10602dceef5b79aa", size = 209922, upload-time = "2026-05-28T12:01:25.522Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e4/966bc240bb0485fc265278f6de44d05834bf0b3618886e0b22e33d54c49a/rpds_py-2026.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:b3cc20c0d800af78fd0fac68086e28c1856cec51ea528bb81ea851aa40d39325", size = 226003, upload-time = "2026-05-28T12:01:27.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5c/a15a59269cd5e74472734516c73795c15eccfc841b3d4b0228c3f53f19d0/rpds_py-2026.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:3609e9939a8a76cd904cf98a3f1f13b5dc7e150adeaee89e0ea09652ea213e16", size = 221245, upload-time = "2026-05-28T12:01:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/135ce03804e179a71ceb13be095deda4a279bc88f7a6b8fa161c5ad44e12/rpds_py-2026.5.1-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:5d333a7127d4b307601ac37792bee01bb95c867cbfacf21b6375b804d6bbd723", size = 352015, upload-time = "2026-05-28T12:01:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/f1f6d2652eb9d848f6eb369d8db83a2da6249bb49ad2c2a48f45d54538d3/rpds_py-2026.5.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:b5f077b44a4f7808520f66dae234988d867deb9aed9be5da057ce9ba831b2a41", size = 345016, upload-time = "2026-05-28T12:01:31.656Z" },
+    { url = "https://files.pythonhosted.org/packages/88/66/b74182775691ea2290c99e52ac8d5db844e56fbec90ce421f107658c8314/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55d8f9b7b78c9538fc9e04e82ec0e888ff0c3cffcfad152c77e57cd09351a98a", size = 374775, upload-time = "2026-05-28T12:01:33.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8f/15e5a61d9f0a43902d36561d4f07cae6ae9f4716be825159fd72717f33af/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e3a8ae58895ac107ed934a6bf51e5846f95c53b9b940c2c6d310838fd5846358", size = 380270, upload-time = "2026-05-28T12:01:34.574Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c3/f859b12763a80540cdf2af0f15b19904cf756a71d7bdd3f82ff3e5b1bbf9/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0957cf3c2b8632ec7aaebffebea8005b353cc2a237b6e2ae3c2cac0820704cfb", size = 495285, upload-time = "2026-05-28T12:01:36.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/ff27c2ac8411d30b03b1829fd88cae8dad1a4d0da48dd25e57c4038042e6/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c396c1304de421050b3681ea70f371874b54d41b0151e96109758144c231e30b", size = 389581, upload-time = "2026-05-28T12:01:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/67/fe92ee32a6cc05c77228a2f8b1762e7124f386ec20ff83d0757b762d58d0/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aad1bff7f666b9598e573815affd666aac6a13a585dde336f843e33350c7fadc", size = 376041, upload-time = "2026-05-28T12:01:39.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/b4d6685c27aba55bd82f25b278be8237038117d05f9659a6213ad3408130/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:656a042550878f12d45752452d47094b7cfe5ad1e9d7b87b5a22ad3ae5ff8015", size = 383946, upload-time = "2026-05-28T12:01:41.043Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/79/2c1d832a53c8e0f8e98fc970ec257b950fecd4f62be2ab7182b500a0cbc8/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c4bd4f70294737b5206a3e8e30ccadbf8a60301831c8ea23eec5dbeea1ecfa", size = 405526, upload-time = "2026-05-28T12:01:43.032Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c4/c98117b03c6a8581ab2c2dfccfe9a5ad82bd8128a3c28b46a6ad2d97c393/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:43bca78665423cabae77146f2fe7ce55272b6c8d55d82cca83effd42c7e13972", size = 551165, upload-time = "2026-05-28T12:01:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c1/bc479ca069200af730881b1bd525e3114b2b391a351509fcb1b772f28086/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:42d0f20e85e549c870749d0e247f0c10d318a45b7e9676d575d2dcb04a1b2e66", size = 618778, upload-time = "2026-05-28T12:01:46.337Z" },
+    { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
+    { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.26.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.49.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
+]


### PR DESCRIPTION
Supersedes #1 by integrating @nbrachet's "Add historical and aggregate reads" on
top of the current `main` (which already contains the OPC UA method/boolean bug
fixes), with review feedback applied and an end-to-end test suite added.

The original commits are preserved (authorship intact); #1 cannot be updated
directly because it originates from a fork with "allow edits by maintainers" off.

## What's included
- **PR #1 feature**: `read_history_opcua_node` (both servers) and
  `read_aggregate_opcua_node` (npx), each exposed only when the server advertises
  the capability. Mock server historizes all variables.
- **Conflicts with `main` resolved** (kept the fixed Boolean method return and the
  `String()` value coercion).

## Review fixes applied on top of #1
- Unify the history tool name: Python `history_read_opcua_node` →
  `read_history_opcua_node` (matches npx).
- Gate the Python history tool on capability — probe `AccessHistoryDataCapability`
  (`ns=0;i=11193`) at startup and register the tool only when supported (mirrors npx).
- npx: convert `start_time`/`end_time` strings to `Date` via `toDate()` in the
  history + aggregate handlers; ISO-8601 works, invalid input returns a clear error.
- npx: route stray `console.log` (node-opcua PKI/cert messages) to stderr so the
  stdio JSON-RPC transport is not corrupted.
- Python: fix the read-history return annotation `[dict]` → `list[dict]`.
- Docs updated for the unified tool name.

## Tests
New `tests/` suite drives **both** servers over stdio with the official `mcp` SDK
against the mock server. **22/22 pass** (11 cases × python + npx): core tools,
capability gating (history exposed, aggregate hidden), boolean writes, method
calls, and history reads. `EXAMPLES.md` documents every tool.

```
cd tests && uv run pytest -v   # 22 passed
```

## Documentation
- **CONTRIBUTING.md** — repo layout, local dev setup, adding a tool to both servers, PR conventions.
- **TESTING.md** — three testing paths: automated `pytest` suite, MCP Inspector (UI + CLI), and AI agents (Claude Code / Desktop / Cursor) with example prompts + troubleshooting.
- **EXAMPLES.md** — per-tool inputs/outputs and node-ID reference.
- README links the above.

## Note
`read_aggregate_opcua_node` is implemented but not exercisable against the bundled
mock (freeopcua advertises no aggregate functions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

