### PR TITLE
feat(python): add aggregate OPC UA read tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
           npm ci
           npm run build
 
+      - name: Install aggregate mock OPC UA server
+        working-directory: packages/mock-server-aggregate
+        run: npm ci
+
       - name: Sync workspace (all packages)
         run: uv sync --all-packages
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -171,7 +171,7 @@ npx (also accepts ISO-8601 `start_time`/`end_time`):
 ```
 > Prompt: *"Show the last 5 temperature readings from history."*
 
-### `read_aggregate_opcua_node` (npx only)
+### `read_aggregate_opcua_node` (both servers)
 Computes aggregates (Average, Minimum, Maximum, …) over a time range, one value
 per `processing_interval` (ms). **Requires a server that advertises aggregate
 functions** — the bundled mock does not, so this tool is not exposed against it.

--- a/packages/mock-server-aggregate/README.md
+++ b/packages/mock-server-aggregate/README.md
@@ -1,0 +1,40 @@
+# Aggregate-capable mock OPC UA server
+
+A small `node-opcua` server used by the end-to-end test suite to exercise
+`read_aggregate_opcua_node` on both MCP servers. Listens on **:4841**
+(`opc.tcp://localhost:4841/UA/Aggregate`).
+
+## Why a second mock
+
+The main mock (`packages/mock-server`) stays deliberately aggregate-free:
+
+- It advertises **no** aggregate functions, which is what lets the suite assert
+  that both MCP servers *hide* the aggregate tool when the server cannot support
+  it (`test_aggregate_tool_hidden_when_unsupported`).
+- It could not serve aggregates anyway — python-opcua's history manager answers
+  `ReadProcessedDetails` with `BadNotImplemented`.
+
+This server covers the positive cases. `node-opcua-aggregates` publishes the
+standard aggregate function nodes under `ServerCapabilities/AggregateFunctions`
+and provides a real `ReadProcessedDetails` implementation, so both MCP servers
+expose the tool against it and compute genuine values.
+
+## Address space
+
+| Node | Node ID | Notes |
+|---|---|---|
+| `Plant/Temperature` | `ns=1;i=1001` | `Double`, historized, ramps **+1.0 per second** |
+
+The ramp is deliberate and linear so aggregates can be checked arithmetically:
+consecutive `Average` buckets must differ by exactly `processing_interval / 1000`.
+`AccessHistoryDataCapability` is set, so the raw history tool is exposed too.
+
+## Running
+
+```bash
+npm install
+npm start          # or: node server.mjs
+```
+
+Override the port with `AGGREGATE_MOCK_PORT`. The test fixture reuses an
+instance already listening on :4841 and otherwise starts one for the session.

--- a/packages/mock-server-aggregate/package-lock.json
+++ b/packages/mock-server-aggregate/package-lock.json
@@ -1,0 +1,2014 @@
+{
+  "name": "opcua-mock-aggregate-server",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "opcua-mock-aggregate-server",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua": "^2.128.0",
+        "node-opcua-aggregates": "^2.128.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT"
+    },
+    "node_modules/@peculiar/asn1-asym-key": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-asym-key/-/asn1-asym-key-2.9.4.tgz",
+      "integrity": "sha512-s7SJfjcXlR3MYMngDTeMLCy3VjGaIxeEy905CQ0j09pDbeYhNBvBGA7r7cAvCZYkVFo9kVg9RAki0K2iUz7SGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-pkcs8": "^2.9.4",
+        "@peculiar/asn1-schema": "^2.9.4",
+        "@peculiar/asn1-x509": "^2.9.4",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.9.4.tgz",
+      "integrity": "sha512-cben7oxmQsUGZqotus7yt0srYdncOT6RNWcTQ77T2RFOXejYVYkXadrfePdRcrVpO9K95IRLKKglG2k38jKXuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.9.4",
+        "@peculiar/asn1-x509": "^2.9.4",
+        "@peculiar/asn1-x509-attr": "^2.9.4",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.9.4.tgz",
+      "integrity": "sha512-xd4YN4vpRjkDAQWVfZZkeu12IEND7DOpkqaHSIHxZl1uggUNa9Ju0QxY2jHvDAS9pP0zhRBytg8ifsnGo3V0jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.9.4",
+        "@peculiar/asn1-x509": "^2.9.4",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.9.4.tgz",
+      "integrity": "sha512-JJXefFshRAuVAjWQo/39bkg1ywc1VaiO44S8RRC+Ykvf/u2KDmYffoDb0ZBPCR5uJy4AGKQhl8mX+Q8ShcWaXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.9.4",
+        "@peculiar/asn1-x509": "^2.9.4",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.9.4.tgz",
+      "integrity": "sha512-khuGzHTzNzk4GDlIBEILyIs6Lce0yn0ZBdoI9v93kmNncfZRhD+AQ5ODFqdhvoE8cMJF/JMTQ8yA+t1D14kqCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.9.4",
+        "@peculiar/asn1-pkcs8": "^2.9.4",
+        "@peculiar/asn1-rsa": "^2.9.4",
+        "@peculiar/asn1-schema": "^2.9.4",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.9.4.tgz",
+      "integrity": "sha512-duRdotlUx9eDZe6QrQpQKl61RbWykCHBCkKayP8V8XdEFwlKHZ8qGGDMyS6Pye7OX7nLFttTTpRkJeet78ckwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.9.4",
+        "@peculiar/asn1-x509": "^2.9.4",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.9.4.tgz",
+      "integrity": "sha512-kaL4cNxBpdQE2dKlyZBqz4ygCrwffO+8wfoxTEqM1Z8RadvCeELBRzcv0dzM8aY9azHMwODO5nxU65zXmhToOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.9.4",
+        "@peculiar/asn1-pfx": "^2.9.4",
+        "@peculiar/asn1-pkcs8": "^2.9.4",
+        "@peculiar/asn1-schema": "^2.9.4",
+        "@peculiar/asn1-x509": "^2.9.4",
+        "@peculiar/asn1-x509-attr": "^2.9.4",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.9.4.tgz",
+      "integrity": "sha512-pZ96eD1PptovcWQ/GSmuNFXd/7EQJNlKfDaNCyE2rx3W0v6QFelkzquVqRSRyyDXXCYD69ZXJDzZ8GhIiQzKoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.9.4",
+        "@peculiar/asn1-x509": "^2.9.4",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.9.4.tgz",
+      "integrity": "sha512-GjzePcT9Iw8NzeOPf73iNS9xM+TBhd/FilAfP+RQGkTMQJTVWtytN3JHJACCjf/ABNau5S7mS3g+DcuxmRgYEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.9.4.tgz",
+      "integrity": "sha512-CxhBo/RdEbMMob7T31ZdQjGuoyRFLVwrDzTn25bihzBasRg9kRm/0IxIPvhgQtcK/9dNcO1XQL2fuPugwELL0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.9.4",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.9.4.tgz",
+      "integrity": "sha512-ehQXbpQaQYycgu8OrvigwSPTFfVRcu0ECNYCWw+yzBp02Lw5paRqzzhUpfOgO2K38+WfFZuEz/0RPtam5g0OMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.9.4",
+        "@peculiar/asn1-x509": "^2.9.4",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-post-quantum": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-post-quantum/-/asn1-x509-post-quantum-2.9.4.tgz",
+      "integrity": "sha512-GD0k7BY3dsEIeai7C7bVRPddj/PzZu+sTawRPRxdHKbdy1f9b58WQyk0eFJdr28GShyLVTU8poyi4+bTAZfEtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-asym-key": "^2.9.4",
+        "@peculiar/asn1-schema": "^2.9.4",
+        "@peculiar/asn1-x509": "^2.9.4",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz",
+      "integrity": "sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/json-schema": "^1.1.12",
+        "@peculiar/utils": "^2.0.2",
+        "tslib": "^2.8.1",
+        "webcrypto-core": "^1.9.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-2.1.0.tgz",
+      "integrity": "sha512-IYbg1R03CSQGWwl24kGyqrdVtixNSbRaDvBg1r5wyYjTP+VwPQkka1BzTgU5+vxiuwqg04OxdvdJ1xYYFIdUSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.9.4",
+        "@peculiar/asn1-csr": "^2.9.4",
+        "@peculiar/asn1-ecc": "^2.9.4",
+        "@peculiar/asn1-pkcs9": "^2.9.4",
+        "@peculiar/asn1-rsa": "^2.9.4",
+        "@peculiar/asn1-schema": "^2.9.4",
+        "@peculiar/asn1-x509": "^2.9.4",
+        "@peculiar/asn1-x509-post-quantum": "^2.9.4",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@ster5/global-mutex": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@ster5/global-mutex/-/global-mutex-3.3.0.tgz",
+      "integrity": "sha512-uiGJTiE0ZiQ6z9VMOHVT3RNrErCi3pZh1bGbfb27GAXCAsvCyLz61pLfBYq8uzsf6Y2qdybhoTwHy7UGtK6MYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependenciesMeta": {
+        "proper-lockfile": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/dns-packet": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.5.tgz",
+      "integrity": "sha512-qXOC7XLOEe43ehtWJCMnQXvgcIpv6rPmQ1jXT98Ad8A3TB1Ue50jsCbSSSyuazScEuZ/Q026vHbrOTVkmwA+7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/multicast-dns": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/@types/multicast-dns/-/multicast-dns-7.2.4.tgz",
+      "integrity": "sha512-ib5K4cIDR4Ro5SR3Sx/LROkMDa0BHz0OPaCBL/OSPDsAXEGZ3/KQeS6poBKYVN7BfjXDL9lWNwzyHVgt/wkyCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/dns-packet": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.5.0.tgz",
+      "integrity": "sha512-dVSGpriSoCgz8WnDNTuSSuSv1PC/ALXihO4ulRZt7Md8k9mlbdin3lGOcDE8SnWOgf513ByWlXd7BK4azmyg/A==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.9.0"
+      }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+      "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
+      "license": "MIT"
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/backoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha512-wC5ihrnUXmR2douXmXLCe5O3zg3GKIyvRi/hi58a/XyRxVI+3/yM0PYueQOZXPXQ9pxBislYkw+sF9b7C/RuMA==",
+      "license": "MIT",
+      "dependencies": {
+        "precond": "0.2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/byline": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/command-line-args": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.2.tgz",
+      "integrity": "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.3",
+        "find-replace": "^5.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/dequeue": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/dequeue/-/dequeue-1.0.5.tgz",
+      "integrity": "sha512-2FIVJZTaWhUj0Y2uKmDAasTP6ZwFWRjkRc01MYN5jFm96iIzkYyNzGADfJ13C5W7CTN7XO9mBYDcVB68eNybBA==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/dns-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+      "integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg==",
+      "license": "MIT"
+    },
+    "node_modules/dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/find-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hexy": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.4.0.tgz",
+      "integrity": "sha512-HxJ6HCV/zrSBeAVRNEhr3CE6yTlCYklMHfCVfJkp7kC+HJqSP1SQ+howWPiHK37t++ELUtgoAoGJut5HyRhIvg==",
+      "license": "MIT",
+      "bin": {
+        "hexy": "bin/hexy_cmd.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/humanize": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/humanize/-/humanize-0.0.9.tgz",
+      "integrity": "sha512-bvZZ7vXpr1RKoImjuQ45hJb5OvE2oJafHysiD/AL3nkqTZH2hFCjQ3YZfCd63FefDitbJze/ispUPP0gfDsT2Q==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.partition": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.partition/-/lodash.partition-4.6.0.tgz",
+      "integrity": "sha512-35L3dSF3Q6V1w5j6V3NhNlQjzsRDC/pYKCTdYTmwqSib+Q8ponkAmt/PwEOq3EmI38DSCl+SkIVwLd+uSlVdrg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/multicast-dns": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+      "license": "MIT",
+      "dependencies": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      }
+    },
+    "node_modules/node-opcua": {
+      "version": "2.182.2",
+      "resolved": "https://registry.npmjs.org/node-opcua/-/node-opcua-2.182.2.tgz",
+      "integrity": "sha512-0fpCl3KVOvn0kGK4SZsQYc8HQQXpnKBMjIDQK7AsEKiqyyb7eb3lBpiYDqNsUrjHGituuv6F5gWH0rVjZIKK4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/semver": "7.8.0",
+        "chalk": "4.1.2",
+        "node-opcua-address-space": "2.182.2",
+        "node-opcua-address-space-for-conformance-testing": "2.182.2",
+        "node-opcua-aggregates": "2.182.2",
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-binary-stream": "2.181.0",
+        "node-opcua-certificate-manager": "2.182.1",
+        "node-opcua-client": "2.182.2",
+        "node-opcua-client-proxy": "2.182.1",
+        "node-opcua-common": "2.182.0",
+        "node-opcua-constants": "2.181.0",
+        "node-opcua-crypto": "5.10.1",
+        "node-opcua-data-access": "2.182.0",
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-data-value": "2.182.0",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-enum": "2.181.0",
+        "node-opcua-factory": "2.182.0",
+        "node-opcua-hostname": "2.181.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-nodesets": "2.182.0",
+        "node-opcua-numeric-range": "2.182.0",
+        "node-opcua-packet-analyzer": "2.182.0",
+        "node-opcua-secure-channel": "2.182.1",
+        "node-opcua-server": "2.182.2",
+        "node-opcua-server-discovery": "2.182.2",
+        "node-opcua-service-browse": "2.182.0",
+        "node-opcua-service-call": "2.182.0",
+        "node-opcua-service-discovery": "2.182.0",
+        "node-opcua-service-endpoints": "2.182.0",
+        "node-opcua-service-filter": "2.182.2",
+        "node-opcua-service-history": "2.182.0",
+        "node-opcua-service-node-management": "2.182.0",
+        "node-opcua-service-query": "2.182.0",
+        "node-opcua-service-read": "2.182.0",
+        "node-opcua-service-register-node": "2.182.0",
+        "node-opcua-service-secure-channel": "2.182.0",
+        "node-opcua-service-session": "2.182.0",
+        "node-opcua-service-subscription": "2.182.1",
+        "node-opcua-service-translate-browse-path": "2.182.0",
+        "node-opcua-service-write": "2.182.0",
+        "node-opcua-status-code": "2.181.0",
+        "node-opcua-transport": "2.182.0",
+        "node-opcua-types": "2.182.0",
+        "node-opcua-utils": "2.181.0",
+        "node-opcua-variant": "2.182.0",
+        "node-opcua-vendor-diagnostic": "2.182.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/erossignon"
+      }
+    },
+    "node_modules/node-opcua-address-space": {
+      "version": "2.182.2",
+      "resolved": "https://registry.npmjs.org/node-opcua-address-space/-/node-opcua-address-space-2.182.2.tgz",
+      "integrity": "sha512-i4PCRfIAPvWTWQgRLmlr3FXpF6Xj5y+RrrHq1Nlns8Hb7oloovHjVb2iTk1I+1Eoxmbc+GNm0GJbvULgWgV0sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/semver": "7.8.0",
+        "chalk": "4.1.2",
+        "dequeue": "^1.0.5",
+        "node-opcua-address-space-base": "2.182.0",
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-binary-stream": "2.181.0",
+        "node-opcua-client-dynamic-extension-object": "2.182.1",
+        "node-opcua-constants": "2.181.0",
+        "node-opcua-crypto": "5.10.1",
+        "node-opcua-data-access": "2.182.0",
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-data-value": "2.182.0",
+        "node-opcua-date-time": "2.181.0",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-enum": "2.181.0",
+        "node-opcua-extension-object": "2.182.0",
+        "node-opcua-factory": "2.182.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-nodeset-ua": "2.182.0",
+        "node-opcua-numeric-range": "2.182.0",
+        "node-opcua-object-registry": "2.181.0",
+        "node-opcua-pseudo-session": "2.182.1",
+        "node-opcua-service-browse": "2.182.0",
+        "node-opcua-service-call": "2.182.0",
+        "node-opcua-service-history": "2.182.0",
+        "node-opcua-service-translate-browse-path": "2.182.0",
+        "node-opcua-service-write": "2.182.0",
+        "node-opcua-status-code": "2.181.0",
+        "node-opcua-types": "2.182.0",
+        "node-opcua-utils": "2.181.0",
+        "node-opcua-variant": "2.182.0",
+        "node-opcua-xml2json": "2.182.0",
+        "semver": "^7.8.5",
+        "thenify-ex": "4.4.0",
+        "xml-writer": "^1.7.0"
+      },
+      "bin": {
+        "opcua-nodeset-image": "bin/opcua-nodeset-image.js",
+        "opcua-nodeset-live": "bin/opcua-nodeset-live.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/node-opcua-address-space-base": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-address-space-base/-/node-opcua-address-space-base-2.182.0.tgz",
+      "integrity": "sha512-RKNLft7oZXJlTQs79m+CK6BwyCofTc4WGCa6F/PVfC2ZgMlZabDR02uvOuRapPq6GjD8S+WYqI+v36viuP+hpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-constants": "2.181.0",
+        "node-opcua-crypto": "5.10.1",
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-data-value": "2.182.0",
+        "node-opcua-date-time": "2.181.0",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-extension-object": "2.182.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-numeric-range": "2.182.0",
+        "node-opcua-schemas": "2.182.0",
+        "node-opcua-status-code": "2.181.0",
+        "node-opcua-types": "2.182.0",
+        "node-opcua-variant": "2.182.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/node-opcua-address-space-for-conformance-testing": {
+      "version": "2.182.2",
+      "resolved": "https://registry.npmjs.org/node-opcua-address-space-for-conformance-testing/-/node-opcua-address-space-for-conformance-testing-2.182.2.tgz",
+      "integrity": "sha512-0uAJmHtJN21Yjka6j9Mu77M34C4DC0mmqTmW5KFqeA2xZ7wseJN8+1ROC1YWmVn4KGg7fsP8Dso4LJE0z8hwCw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-address-space": "2.182.2",
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-data-access": "2.182.0",
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-data-value": "2.182.0",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-factory": "2.182.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-status-code": "2.181.0",
+        "node-opcua-variant": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-aggregates": {
+      "version": "2.182.2",
+      "resolved": "https://registry.npmjs.org/node-opcua-aggregates/-/node-opcua-aggregates-2.182.2.tgz",
+      "integrity": "sha512-b7daweWQH9UUXqbRbozOidOy4t/FNYCanX8ekOOTnoc9jflRQVcuGMtKrJPZnLdnzb0obCVS0EtKbVLEminT9w==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-address-space": "2.182.2",
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-constants": "2.181.0",
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-data-value": "2.182.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-numeric-range": "2.182.0",
+        "node-opcua-server": "2.182.2",
+        "node-opcua-service-history": "2.182.0",
+        "node-opcua-status-code": "2.181.0",
+        "node-opcua-types": "2.182.0",
+        "node-opcua-utils": "2.181.0",
+        "node-opcua-variant": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-alarm-condition": {
+      "version": "2.182.2",
+      "resolved": "https://registry.npmjs.org/node-opcua-alarm-condition/-/node-opcua-alarm-condition-2.182.2.tgz",
+      "integrity": "sha512-u5Dq+7+IzElXc2GTYWTybbN7UHaL+Uzy+lex7hifNGHEouu77uyGbEiq3+ZyvVJkGo2IVs9Ggu1zM+GkWqyhGw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-constants": "2.181.0",
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-pseudo-session": "2.182.1",
+        "node-opcua-service-filter": "2.182.2",
+        "node-opcua-service-read": "2.182.0",
+        "node-opcua-service-subscription": "2.182.1",
+        "node-opcua-service-translate-browse-path": "2.182.0",
+        "node-opcua-status-code": "2.181.0",
+        "node-opcua-types": "2.182.0",
+        "node-opcua-utils": "2.181.0",
+        "node-opcua-variant": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-assert": {
+      "version": "2.179.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-assert/-/node-opcua-assert-2.179.0.tgz",
+      "integrity": "sha512-M8nIf+BC2QUo2AVYvJef5rG+2YNTuZGFNES/GpZ892JAPE/LdYrlIJ4DHxX8GbQgU+s2/2Dw7DxmCFtWZ0vt5A==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2"
+      }
+    },
+    "node_modules/node-opcua-basic-types": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-basic-types/-/node-opcua-basic-types-2.182.0.tgz",
+      "integrity": "sha512-/ZMt0gv5ZigiuerD/TQ5pq8qq5yi2d1inJAjCrX/RjvCF6fzNLkzd1RZpCERX3hPCVncZ3Cyf1QDa90aLhc6cg==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-binary-stream": "2.181.0",
+        "node-opcua-buffer-utils": "2.181.0",
+        "node-opcua-date-time": "2.181.0",
+        "node-opcua-guid": "2.181.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-status-code": "2.181.0"
+      }
+    },
+    "node_modules/node-opcua-binary-stream": {
+      "version": "2.181.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-binary-stream/-/node-opcua-binary-stream-2.181.0.tgz",
+      "integrity": "sha512-KodkU1lfVVvkfHBbb1NV7WnFxWgUbOJqBd6l8jR1Zc9l3vo47Vlnyp7I8Ff/Jfx7gW7+07hHXKVlLgDVz+lYCA==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-buffer-utils": "2.181.0"
+      }
+    },
+    "node_modules/node-opcua-buffer-utils": {
+      "version": "2.181.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-buffer-utils/-/node-opcua-buffer-utils-2.181.0.tgz",
+      "integrity": "sha512-U/zTkuj7CB3s9eLxejztZNIO12Dyo7cwq3Bt8MB0wAoZs3X7i42sbSYJbQIKmN4IloieWDTWfFn4QCvtufEw8w==",
+      "license": "MIT"
+    },
+    "node_modules/node-opcua-certificate-manager": {
+      "version": "2.182.1",
+      "resolved": "https://registry.npmjs.org/node-opcua-certificate-manager/-/node-opcua-certificate-manager-2.182.1.tgz",
+      "integrity": "sha512-mfe9kw3Vqb/BiTVaoApj3DKrp3NgbwLvw5213UcJjyFB9v1ZkjbhrUdu/9AQIZ+sOmMjm0tqY1j0+mRfEuk6wg==",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "2.2.1",
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-common": "2.182.0",
+        "node-opcua-crypto": "5.10.1",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-object-registry": "2.181.0",
+        "node-opcua-pki": "6.22.0",
+        "node-opcua-status-code": "2.181.0",
+        "thenify-ex": "4.4.0"
+      }
+    },
+    "node_modules/node-opcua-chunkmanager": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-chunkmanager/-/node-opcua-chunkmanager-2.182.0.tgz",
+      "integrity": "sha512-WrVibKu0yMgE+hU4ThFewqXv1VnVu847LJED1ST2WS/oy2LkI37I3rv5x4WVbYhyIu4v9n1j8cm70VcUy+2GKw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-binary-stream": "2.181.0",
+        "node-opcua-buffer-utils": "2.181.0",
+        "node-opcua-factory": "2.182.0",
+        "node-opcua-packet-assembler": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-client": {
+      "version": "2.182.2",
+      "resolved": "https://registry.npmjs.org/node-opcua-client/-/node-opcua-client-2.182.2.tgz",
+      "integrity": "sha512-hj/mt9S2XO7yrDqQBL5Tpu+vOGm9mqrhTf6UGX5nhGSRdcZDU/AnNKyL3cJavzGJ6oVqGHrkfvtnbZ5eNgf6ig==",
+      "license": "MIT",
+      "dependencies": {
+        "@ster5/global-mutex": "^3.3.0",
+        "chalk": "4.1.2",
+        "node-opcua-alarm-condition": "2.182.2",
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-buffer-utils": "2.181.0",
+        "node-opcua-certificate-manager": "2.182.1",
+        "node-opcua-client-dynamic-extension-object": "2.182.1",
+        "node-opcua-common": "2.182.0",
+        "node-opcua-constants": "2.181.0",
+        "node-opcua-crypto": "5.10.1",
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-data-value": "2.182.0",
+        "node-opcua-date-time": "2.181.0",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-extension-object": "2.182.0",
+        "node-opcua-hostname": "2.181.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-numeric-range": "2.182.0",
+        "node-opcua-object-registry": "2.181.0",
+        "node-opcua-pki": "6.22.0",
+        "node-opcua-pseudo-session": "2.182.1",
+        "node-opcua-schemas": "2.182.0",
+        "node-opcua-secure-channel": "2.182.1",
+        "node-opcua-service-browse": "2.182.0",
+        "node-opcua-service-call": "2.182.0",
+        "node-opcua-service-discovery": "2.182.0",
+        "node-opcua-service-endpoints": "2.182.0",
+        "node-opcua-service-filter": "2.182.2",
+        "node-opcua-service-history": "2.182.0",
+        "node-opcua-service-query": "2.182.0",
+        "node-opcua-service-read": "2.182.0",
+        "node-opcua-service-register-node": "2.182.0",
+        "node-opcua-service-secure-channel": "2.182.0",
+        "node-opcua-service-session": "2.182.0",
+        "node-opcua-service-subscription": "2.182.1",
+        "node-opcua-service-translate-browse-path": "2.182.0",
+        "node-opcua-service-write": "2.182.0",
+        "node-opcua-status-code": "2.181.0",
+        "node-opcua-transport": "2.182.0",
+        "node-opcua-types": "2.182.0",
+        "node-opcua-utils": "2.181.0",
+        "node-opcua-variant": "2.182.0",
+        "thenify-ex": "4.4.0"
+      }
+    },
+    "node_modules/node-opcua-client-dynamic-extension-object": {
+      "version": "2.182.1",
+      "resolved": "https://registry.npmjs.org/node-opcua-client-dynamic-extension-object/-/node-opcua-client-dynamic-extension-object-2.182.1.tgz",
+      "integrity": "sha512-MzVFyIhMp0tRdSenfNmqIcEMPEfZNP3SJKa1ztq4CwAZPTK7yNNbvgRwIF59XYtMhKaodn426EuCptG7WN4waA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-binary-stream": "2.181.0",
+        "node-opcua-constants": "2.181.0",
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-data-value": "2.182.0",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-extension-object": "2.182.0",
+        "node-opcua-factory": "2.182.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-pseudo-session": "2.182.1",
+        "node-opcua-schemas": "2.182.0",
+        "node-opcua-service-browse": "2.182.0",
+        "node-opcua-service-translate-browse-path": "2.182.0",
+        "node-opcua-status-code": "2.181.0",
+        "node-opcua-types": "2.182.0",
+        "node-opcua-variant": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-client-proxy": {
+      "version": "2.182.1",
+      "resolved": "https://registry.npmjs.org/node-opcua-client-proxy/-/node-opcua-client-proxy-2.182.1.tgz",
+      "integrity": "sha512-Y1gbk+Swn5GHYxPMQILslSpb7hse7tiJE9qyFmKdg61VSbE+VZV/VYIG3KZSnPZ1FNhzH6FjUVX+TXZfWpqW6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-constants": "2.181.0",
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-data-value": "2.182.0",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-pseudo-session": "2.182.1",
+        "node-opcua-service-browse": "2.182.0",
+        "node-opcua-service-call": "2.182.0",
+        "node-opcua-service-read": "2.182.0",
+        "node-opcua-service-subscription": "2.182.1",
+        "node-opcua-service-write": "2.182.0",
+        "node-opcua-status-code": "2.181.0",
+        "node-opcua-utils": "2.181.0",
+        "node-opcua-variant": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-common": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-common/-/node-opcua-common-2.182.0.tgz",
+      "integrity": "sha512-NGqXcW8sGmQpEDdHh8eD8EQc/NmVJVyNELl628vK9Is78WqxKCrHjxEyRg//QT+DYUYhCcVY5lXgoiPGCYu4ow==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-crypto": "5.10.1",
+        "node-opcua-status-code": "2.181.0",
+        "node-opcua-types": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-constants": {
+      "version": "2.181.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-constants/-/node-opcua-constants-2.181.0.tgz",
+      "integrity": "sha512-fx4FNcmMImQqjChpK+eBYEVAFp/m1alBlRlmdGI5KzWSdhS9cSy9X8jrWqqDU4pg/l8l0v3cfeGnzDcDS8qaWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-opcua-crypto": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/node-opcua-crypto/-/node-opcua-crypto-5.10.1.tgz",
+      "integrity": "sha512-cx3PPl90Rxixcx4ONvFp4v7BmIIurXuqibcq5S8xj+AQ5i9EMAkhIw//9i7i5MhM2AuGaxSTIcF+o9zSyrDYvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.9.4",
+        "@peculiar/asn1-pfx": "^2.9.4",
+        "@peculiar/asn1-pkcs8": "^2.9.4",
+        "@peculiar/asn1-pkcs9": "^2.9.4",
+        "@peculiar/asn1-rsa": "^2.9.4",
+        "@peculiar/asn1-schema": "^2.9.4",
+        "@peculiar/asn1-x509": "^2.9.4",
+        "@peculiar/webcrypto": "^1.7.1",
+        "@peculiar/x509": "^2.0.0",
+        "reflect-metadata": "^0.2.2",
+        "sshpk": "^1.18.0"
+      },
+      "peerDependencies": {
+        "node-opcua-crypto-web": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "node-opcua-crypto-web": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-opcua-data-access": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-data-access/-/node-opcua-data-access-2.182.0.tgz",
+      "integrity": "sha512-ZlNfVWoPwkL2ciuLZ7PRyL70US28S1sbas6v9OQOFWA3rfBAB1qup52BbVEt36IPQS7jpieCkjdzrbJ2aGDJeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-types": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-data-model": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-data-model/-/node-opcua-data-model-2.182.0.tgz",
+      "integrity": "sha512-/mAvlCYQGJAfN57dWBRMHFoj16FjA3govxn7nzkbMVaDLv6HOGnpWFuS5gfY1zSxNG7Suv07TndJzsOQfLUDOw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-binary-stream": "2.181.0",
+        "node-opcua-enum": "2.181.0",
+        "node-opcua-factory": "2.182.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-status-code": "2.181.0"
+      }
+    },
+    "node_modules/node-opcua-data-value": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-data-value/-/node-opcua-data-value-2.182.0.tgz",
+      "integrity": "sha512-/ZBhTcBjhBWoXP6S2Zwc9pfKzCvRUTKS3qt4PNg2A0lx13FoOx7xnJO04IDERFR+QoqAiGnDpUwxImoCSHyzFg==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-binary-stream": "2.181.0",
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-date-time": "2.181.0",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-enum": "2.181.0",
+        "node-opcua-factory": "2.182.0",
+        "node-opcua-numeric-range": "2.182.0",
+        "node-opcua-status-code": "2.181.0",
+        "node-opcua-variant": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-date-time": {
+      "version": "2.181.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-date-time/-/node-opcua-date-time-2.181.0.tgz",
+      "integrity": "sha512-vKtEyAYxMr3j+phjgBwJsx6dWx/x5L/dagE75Vo8ogwDsK6SIhSvoBajSTKLv5ZfZtSfbNu9D3E0mFSO/YJ9Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "long": "5.3.2",
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-binary-stream": "2.181.0",
+        "node-opcua-utils": "2.181.0"
+      }
+    },
+    "node_modules/node-opcua-debug": {
+      "version": "2.181.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-debug/-/node-opcua-debug-2.181.0.tgz",
+      "integrity": "sha512-ZV0geb8M6rDg+Gc3mweoY2diBQQiCHV5Nz87Ne2rmM8PoZ/gxbmKg3ybIVmWMYZXi9pzH28XQSP6sYT8UKxBPg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "hexy": "0.4.0",
+        "node-opcua-assert": "2.179.0"
+      }
+    },
+    "node_modules/node-opcua-enum": {
+      "version": "2.181.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-enum/-/node-opcua-enum-2.181.0.tgz",
+      "integrity": "sha512-QF9xQx8H7D5CqmI0Jejst1Ikw0m+ImaahhuWNM8LQNKdVJ3C6xSjkaWNJI7eV9XxxEUuvvtzcD2B/gGRxLBlxQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-opcua-extension-object": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-extension-object/-/node-opcua-extension-object-2.182.0.tgz",
+      "integrity": "sha512-F4/5cgJRrMV86Bh/5kRidGi0ty7auSCRcgpgBwc3HwTjC4EhHsaf80EAqpT2mISaCoX19Cq85MNrOmXi8AXrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-binary-stream": "2.181.0",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-factory": "2.182.0",
+        "node-opcua-nodeid": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-factory": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-factory/-/node-opcua-factory-2.182.0.tgz",
+      "integrity": "sha512-oSz9dNcAf5Orv9ao+3PZauAIXO0r2tH5/W0sy3q7/1kGX+ZRGyWrEpf8yLiqm2n7dezZEX6r0WpJ/hZKF0uDQA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-binary-stream": "2.181.0",
+        "node-opcua-constants": "2.181.0",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-enum": "2.181.0",
+        "node-opcua-guid": "2.181.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-status-code": "2.181.0",
+        "node-opcua-utils": "2.181.0"
+      }
+    },
+    "node_modules/node-opcua-guid": {
+      "version": "2.181.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-guid/-/node-opcua-guid-2.181.0.tgz",
+      "integrity": "sha512-0v1r0KEqXljoYaBfLzZBMowL/zeUvXIu1Z/OkdkHahlgRs85zHJM7BWhv+oSIdw4iOa16XrOSym4ocnRm0xeww==",
+      "license": "MIT"
+    },
+    "node_modules/node-opcua-hostname": {
+      "version": "2.181.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-hostname/-/node-opcua-hostname-2.181.0.tgz",
+      "integrity": "sha512-b3VhaV+ZM+ZQy7p1OxQwD5PMe9bAULsw6hVV/2EknYMjsfCs3X6jOpl3Y3esyGrNvcmGCgEMWv0utAPiWsO7UQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-opcua-json": {
+      "version": "2.182.2",
+      "resolved": "https://registry.npmjs.org/node-opcua-json/-/node-opcua-json-2.182.2.tgz",
+      "integrity": "sha512-DiTZGYbt1YQtlk6c+wRUDk3GS4pVTMa+kZWi8HkjV9uhRRjueZluu0XomVRNTr7k3TXU6F4Dh7mOm847ezThBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-data-value": "2.182.0",
+        "node-opcua-date-time": "2.181.0",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-extension-object": "2.182.0",
+        "node-opcua-factory": "2.182.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-numeric-range": "2.182.0",
+        "node-opcua-status-code": "2.181.0",
+        "node-opcua-types": "2.182.0",
+        "node-opcua-variant": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-nodeid": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-nodeid/-/node-opcua-nodeid-2.182.0.tgz",
+      "integrity": "sha512-0ZbGfu0WK9j0vPaMSSwZG5JkO3fAKfvxldTC2q20byqLdsFLnfBgEGrLkal2054BTwBVN/MPFrUog4sJTLHIjw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-constants": "2.181.0",
+        "node-opcua-guid": "2.181.0"
+      }
+    },
+    "node_modules/node-opcua-nodeset-ua": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-nodeset-ua/-/node-opcua-nodeset-ua-2.182.0.tgz",
+      "integrity": "sha512-9yd8Qmm4OyrOn0XD1CcYA6Mq8AuxTny1ksb8ZxLL8hj381w4YNR0QSWEYDQVvPwYz0z0fygkBN0MZHYlN3IaMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-address-space-base": "2.182.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-data-access": "2.182.0",
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-data-value": "2.182.0",
+        "node-opcua-extension-object": "2.182.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-status-code": "2.181.0",
+        "node-opcua-variant": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-nodesets": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-nodesets/-/node-opcua-nodesets-2.182.0.tgz",
+      "integrity": "sha512-WzGzyXcU5Jc3Mspf7Cqn8wM/ggRG9NGxiwveeaV0Fe5VOHYqwWdt1DdcbT4Sm7tMFtOb2x+xJ8lL71T09vWZBg==",
+      "license": "MIT"
+    },
+    "node_modules/node-opcua-numeric-range": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-numeric-range/-/node-opcua-numeric-range-2.182.0.tgz",
+      "integrity": "sha512-O53gQYuLap9K3wJ4RK682Jl8kzuNdYyAQWmTzeKo1R8HhyIV43Kwi3G4VxR0a+yG61hs+jUj+bB+WpLYGnKmvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-binary-stream": "2.181.0",
+        "node-opcua-factory": "2.182.0",
+        "node-opcua-status-code": "2.181.0"
+      }
+    },
+    "node_modules/node-opcua-object-registry": {
+      "version": "2.181.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-object-registry/-/node-opcua-object-registry-2.181.0.tgz",
+      "integrity": "sha512-9JQ/ZQuXD+OXZOAdL07mtBzb5Vu+pD279HHtHD0MpYHpHFs+srhmaXq+CK7rDpm8g+oVMKkin1QkJ6ktQbUtIg==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-debug": "2.181.0"
+      }
+    },
+    "node_modules/node-opcua-packet-analyzer": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-packet-analyzer/-/node-opcua-packet-analyzer-2.182.0.tgz",
+      "integrity": "sha512-/NRu0iAjr+k5LeHQz89ZzYxZ3YVPYd8XDj5zszYeV++SYlfdMSs5i4M5Cb5m2Y8Ns+W11qSec9L3so3TFISmGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-binary-stream": "2.181.0",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-factory": "2.182.0",
+        "node-opcua-utils": "2.181.0"
+      }
+    },
+    "node_modules/node-opcua-packet-assembler": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-packet-assembler/-/node-opcua-packet-assembler-2.182.0.tgz",
+      "integrity": "sha512-X5RbmrtZZObZXEnFY7GC2ET27nr3Rto09epkd9Nrh78j5n/82F+nrbHRTTrhiD8rz6K2B8meDHvrpBBdGu0SPw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-debug": "2.181.0"
+      }
+    },
+    "node_modules/node-opcua-pki": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-pki/-/node-opcua-pki-6.22.0.tgz",
+      "integrity": "sha512-Fp4DcEzhs1oL4pni5oLcy3DaT0xRKqAfwuAl36sg2BE5IHs/TVqtdqpXnb191F9EzDhwPmNtj7dHl3D1U20kHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ster5/global-mutex": "^3.3.0",
+        "byline": "^5.0.0",
+        "chalk": "4.1.2",
+        "chokidar": "4.0.3",
+        "command-line-args": "^6.0.2",
+        "command-line-usage": "^7.0.4",
+        "node-opcua-crypto": "5.10.1",
+        "yauzl": "^3.4.0"
+      },
+      "bin": {
+        "node-opcua-pki": "dist/bin/pki.mjs",
+        "pki": "dist/bin/pki.mjs"
+      }
+    },
+    "node_modules/node-opcua-pseudo-session": {
+      "version": "2.182.1",
+      "resolved": "https://registry.npmjs.org/node-opcua-pseudo-session/-/node-opcua-pseudo-session-2.182.1.tgz",
+      "integrity": "sha512-BonIK8OjU6w4a7txDZpZmpuYwJzQc5K/venCSYW1WT8Ki+tPnjdlxIG0RI3GGXLFl1y6U3lTG72hy/9Zg2rYBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-constants": "2.181.0",
+        "node-opcua-crypto": "5.10.1",
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-data-value": "2.182.0",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-service-browse": "2.182.0",
+        "node-opcua-service-call": "2.182.0",
+        "node-opcua-service-read": "2.182.0",
+        "node-opcua-service-subscription": "2.182.1",
+        "node-opcua-service-translate-browse-path": "2.182.0",
+        "node-opcua-service-write": "2.182.0",
+        "node-opcua-status-code": "2.181.0",
+        "node-opcua-types": "2.182.0",
+        "node-opcua-utils": "2.181.0",
+        "node-opcua-variant": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-schemas": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-schemas/-/node-opcua-schemas-2.182.0.tgz",
+      "integrity": "sha512-qveQFI49kmkWkjaMiB4sDVBS+Ef9vtU1LAtV+UbqrOOZ0VIW3xFZZUyMtUfZt3iQhJwXhrDD0p+wI85Iu7ktag==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-binary-stream": "2.181.0",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-extension-object": "2.182.0",
+        "node-opcua-factory": "2.182.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-variant": "2.182.0",
+        "node-opcua-xml2json": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-secure-channel": {
+      "version": "2.182.1",
+      "resolved": "https://registry.npmjs.org/node-opcua-secure-channel/-/node-opcua-secure-channel-2.182.1.tgz",
+      "integrity": "sha512-dLflSPH3SUx3NOiaIF3YRGf6lJcvcbxYRr1oMXbEBwD7E3lOFlqHS0FDAeLnKnd/SO9pBzXUJDg1J5g3r7SOIw==",
+      "license": "MIT",
+      "dependencies": {
+        "backoff": "^2.5.0",
+        "chalk": "4.1.2",
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-binary-stream": "2.181.0",
+        "node-opcua-chunkmanager": "2.182.0",
+        "node-opcua-common": "2.182.0",
+        "node-opcua-crypto": "5.10.1",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-factory": "2.182.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-object-registry": "2.181.0",
+        "node-opcua-packet-analyzer": "2.182.0",
+        "node-opcua-packet-assembler": "2.182.0",
+        "node-opcua-service-endpoints": "2.182.0",
+        "node-opcua-service-secure-channel": "2.182.0",
+        "node-opcua-status-code": "2.181.0",
+        "node-opcua-transport": "2.182.0",
+        "node-opcua-types": "2.182.0",
+        "node-opcua-utils": "2.181.0"
+      }
+    },
+    "node_modules/node-opcua-server": {
+      "version": "2.182.2",
+      "resolved": "https://registry.npmjs.org/node-opcua-server/-/node-opcua-server-2.182.2.tgz",
+      "integrity": "sha512-AaDNNvjVbOHfc2mvYR3NtXiPfxOJWjw1rMvK+bzmofPviyzD03L5c/B1JnQ8iMb6DhfqRuvwNjaLfXjEiEYCXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ster5/global-mutex": "^3.3.0",
+        "chalk": "4.1.2",
+        "dequeue": "^1.0.5",
+        "lodash.partition": "^4.6.0",
+        "lodash.sortby": "^4.7.0",
+        "node-opcua-address-space": "2.182.2",
+        "node-opcua-address-space-base": "2.182.0",
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-binary-stream": "2.181.0",
+        "node-opcua-certificate-manager": "2.182.1",
+        "node-opcua-client": "2.182.2",
+        "node-opcua-common": "2.182.0",
+        "node-opcua-constants": "2.181.0",
+        "node-opcua-crypto": "5.10.1",
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-data-value": "2.182.0",
+        "node-opcua-date-time": "2.181.0",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-extension-object": "2.182.0",
+        "node-opcua-factory": "2.182.0",
+        "node-opcua-hostname": "2.181.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-nodesets": "2.182.0",
+        "node-opcua-numeric-range": "2.182.0",
+        "node-opcua-object-registry": "2.181.0",
+        "node-opcua-pki": "6.22.0",
+        "node-opcua-secure-channel": "2.182.1",
+        "node-opcua-service-browse": "2.182.0",
+        "node-opcua-service-call": "2.182.0",
+        "node-opcua-service-discovery": "2.182.0",
+        "node-opcua-service-endpoints": "2.182.0",
+        "node-opcua-service-filter": "2.182.2",
+        "node-opcua-service-history": "2.182.0",
+        "node-opcua-service-node-management": "2.182.0",
+        "node-opcua-service-query": "2.182.0",
+        "node-opcua-service-read": "2.182.0",
+        "node-opcua-service-register-node": "2.182.0",
+        "node-opcua-service-secure-channel": "2.182.0",
+        "node-opcua-service-session": "2.182.0",
+        "node-opcua-service-subscription": "2.182.1",
+        "node-opcua-service-translate-browse-path": "2.182.0",
+        "node-opcua-service-write": "2.182.0",
+        "node-opcua-status-code": "2.181.0",
+        "node-opcua-transport": "2.182.0",
+        "node-opcua-types": "2.182.0",
+        "node-opcua-uanodeset-json": "2.182.2",
+        "node-opcua-utils": "2.181.0",
+        "node-opcua-variant": "2.182.0",
+        "thenify-ex": "4.4.0"
+      }
+    },
+    "node_modules/node-opcua-server-discovery": {
+      "version": "2.182.2",
+      "resolved": "https://registry.npmjs.org/node-opcua-server-discovery/-/node-opcua-server-discovery-2.182.2.tgz",
+      "integrity": "sha512-Up1PtePUlIEaNfKrt7HAVLx6b61vAGcwYVke+is67shZMo/JjjjQmSiR15BxHt3hkxqjwMbXPR4UWon9EA8YaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "env-paths": "2.2.1",
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-certificate-manager": "2.182.1",
+        "node-opcua-common": "2.182.0",
+        "node-opcua-crypto": "5.10.1",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-object-registry": "2.181.0",
+        "node-opcua-secure-channel": "2.182.1",
+        "node-opcua-server": "2.182.2",
+        "node-opcua-service-discovery": "2.182.0",
+        "node-opcua-service-endpoints": "2.182.0",
+        "node-opcua-status-code": "2.181.0",
+        "sterfive-bonjour-service": "1.1.4",
+        "thenify-ex": "4.4.0"
+      }
+    },
+    "node_modules/node-opcua-service-browse": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-browse/-/node-opcua-service-browse-2.182.0.tgz",
+      "integrity": "sha512-xXc0oVt5VM60uJtopdVPg18vEQn1MUzZ64uEBbNlN9eaIW+elWMARRqHQzwPnB9Vb/FTqNE6hfkD7vYdsjIixQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-types": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-service-call": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-call/-/node-opcua-service-call-2.182.0.tgz",
+      "integrity": "sha512-4ePzt50jQGCJKwljrdgNyZlcEhl3BcrheskrE7/ABvOKy1YlPwCY7aHNnV6Cv+vzo72/BDATrmyj2YgIFanEHg==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-types": "2.182.0",
+        "node-opcua-variant": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-service-discovery": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-discovery/-/node-opcua-service-discovery-2.182.0.tgz",
+      "integrity": "sha512-0WDvHH+TjD1N18cXFgtfqHTM91Cx51SKQXwc26/9J27IEPM7+Fv2HQfEQHoOM0XeKelcKPWh6VDzITfMaftkYA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-object-registry": "2.181.0",
+        "node-opcua-types": "2.182.0",
+        "sterfive-bonjour-service": "1.1.4"
+      }
+    },
+    "node_modules/node-opcua-service-endpoints": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-endpoints/-/node-opcua-service-endpoints-2.182.0.tgz",
+      "integrity": "sha512-uM23W01XW8qIT2AviFAVrl9VsVF9puUAauyuGSSNX2LOYcey1rZyv0jOXi1nii7SYY7wlwadLE1F1Q3QRTIR4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-types": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-service-filter": {
+      "version": "2.182.2",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-filter/-/node-opcua-service-filter-2.182.2.tgz",
+      "integrity": "sha512-1/dnzXqkdDNk8z/fO7ChwS99KOt5j+mTdjm1IyOSd/rCzCRvUSMnKSr78VwC+U6zlkklwYXMoWw1ORu4JL1F9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-address-space-base": "2.182.0",
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-constants": "2.181.0",
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-data-value": "2.182.0",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-extension-object": "2.182.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-service-translate-browse-path": "2.182.0",
+        "node-opcua-status-code": "2.181.0",
+        "node-opcua-types": "2.182.0",
+        "node-opcua-variant": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-service-history": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-history/-/node-opcua-service-history-2.182.0.tgz",
+      "integrity": "sha512-/BOcy2NMUgTmlvcLPBMNRQMtpH4a0Dn+h9d/smfMfu8wZLCTra+DvrQcC5oz7lD54Lt7TCs4sqZYuqV0zrlxCg==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-data-value": "2.182.0",
+        "node-opcua-types": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-service-node-management": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-node-management/-/node-opcua-service-node-management-2.182.0.tgz",
+      "integrity": "sha512-bnDSrOe/Ov0/2Ibc6pvefEN26VTVcBfFTnorRNpXlvPdPmMIXeMrSGIkpNHwKak3zMRfpu2WGP9YplSoGpg3JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-types": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-service-query": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-query/-/node-opcua-service-query-2.182.0.tgz",
+      "integrity": "sha512-78NbZkmX0+PyAmmKY7MieVAjviZB0Lne5tSW8yg7ZFhn4cblOorQnTFujVmW6ZLl92HZUV44xVn3luzgp3qXKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-types": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-service-read": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-read/-/node-opcua-service-read-2.182.0.tgz",
+      "integrity": "sha512-MfXCQ7cWu4f+Rtb7LvhXGUnKXEk2VZ3fTpwMBHqTjDMaKD1SSzzw3724ffGHmu2bOTof6bI57FEc7BJhdj6YCw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-data-value": "2.182.0",
+        "node-opcua-service-secure-channel": "2.182.0",
+        "node-opcua-types": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-service-register-node": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-register-node/-/node-opcua-service-register-node-2.182.0.tgz",
+      "integrity": "sha512-akL5x6INWAyRDDZ0xllgMH0UIpsqHuNf/zhYCgOkfBa8/a8KA6iXvEQmZmBVLJ6Wyy8T+/L8v16++jakPslpFA==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-types": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-service-secure-channel": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-secure-channel/-/node-opcua-service-secure-channel-2.182.0.tgz",
+      "integrity": "sha512-dzEMXxCZUnDYt5tQD7LsHKhF8iR+c3OKHk5BAkUhgHM2mebukJc+gIii/Q3G8i9Dslh0YzHgw/+FlT8cn/Z77Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-binary-stream": "2.181.0",
+        "node-opcua-factory": "2.182.0",
+        "node-opcua-types": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-service-session": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-session/-/node-opcua-service-session-2.182.0.tgz",
+      "integrity": "sha512-jgBZiDdfRx5aIQFEQsyf+1laqLybtBYPKozjZSOFQMBAODnfmm5vZXn+qNl+oWtsysHt79gkGy36HbvhEJBQ9A==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-factory": "2.182.0",
+        "node-opcua-types": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-service-subscription": {
+      "version": "2.182.1",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-subscription/-/node-opcua-service-subscription-2.182.1.tgz",
+      "integrity": "sha512-0gE6mjNgBUFQjT/YAG+uAHVWP3kkPfOToL8Ok9tkNQmOGSpEuie6BBZgIhzlo9+dt8h2BgGBhwqgw9ZQT1ljug==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-types": "2.182.0",
+        "node-opcua-variant": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-service-translate-browse-path": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-translate-browse-path/-/node-opcua-service-translate-browse-path-2.182.0.tgz",
+      "integrity": "sha512-pkMQ2S3Hh7RkkJHptwu2/cCRSedrpF40rWzd4GczQSQJNGuqzsKkoMxbJiUWvn54DT+GPaBtpOw7l7szpVlUwg==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-constants": "2.181.0",
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-types": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-service-write": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-write/-/node-opcua-service-write-2.182.0.tgz",
+      "integrity": "sha512-gwfmW3iEJDJPbVns5IyjQ/uBoqBFCn+CocW1xFp8DeX8eRpDqheZIBZWA8Xm5jm8QwsdNapKxWfcaKPV8Bw9wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-types": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-status-code": {
+      "version": "2.181.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-status-code/-/node-opcua-status-code-2.181.0.tgz",
+      "integrity": "sha512-eG5R/GWX88fMUG/HiLm3C9uzwJkRTg17jl1tkzWwzH3d1BY0B4btp90u2R0HqnBS2gy8sfkbzVw0QsdYQysRjA==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-binary-stream": "2.181.0"
+      }
+    },
+    "node_modules/node-opcua-transport": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-transport/-/node-opcua-transport-2.182.0.tgz",
+      "integrity": "sha512-McIwrjSiUDSQuwueT7fQrxNbV+O5h5VjyPUPaBdoFGWmHoZOYKSdxEGEOZz1BgK9m2brfBxmHOeXERvEx2JflA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-binary-stream": "2.181.0",
+        "node-opcua-buffer-utils": "2.181.0",
+        "node-opcua-chunkmanager": "2.182.0",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-factory": "2.182.0",
+        "node-opcua-object-registry": "2.181.0",
+        "node-opcua-packet-assembler": "2.182.0",
+        "node-opcua-status-code": "2.181.0",
+        "node-opcua-utils": "2.181.0"
+      }
+    },
+    "node_modules/node-opcua-types": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-types/-/node-opcua-types-2.182.0.tgz",
+      "integrity": "sha512-2xnZQC8YPFnYN7YbaJkzEFmBFu9nEkMHbUl/O+cQTE/NYb0nsTQbUtLseS0ubdCyNJXBsCPE8hCqnIfokmJizQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-binary-stream": "2.181.0",
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-data-value": "2.182.0",
+        "node-opcua-enum": "2.181.0",
+        "node-opcua-extension-object": "2.182.0",
+        "node-opcua-factory": "2.182.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-numeric-range": "2.182.0",
+        "node-opcua-status-code": "2.181.0",
+        "node-opcua-variant": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-uanodeset-json": {
+      "version": "2.182.2",
+      "resolved": "https://registry.npmjs.org/node-opcua-uanodeset-json/-/node-opcua-uanodeset-json-2.182.2.tgz",
+      "integrity": "sha512-WlweN4/xrpx5YWXFnurbVMeQ4oWLqb4gQPO78Sn+lk8hO/SRglJ1T8Vy7wi2olkJUEyd2o/aSqQszLO08EVPLw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-address-space": "2.182.2",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-date-time": "2.181.0",
+        "node-opcua-extension-object": "2.182.0",
+        "node-opcua-factory": "2.182.0",
+        "node-opcua-json": "2.182.2",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-variant": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-utils": {
+      "version": "2.181.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-utils/-/node-opcua-utils-2.181.0.tgz",
+      "integrity": "sha512-oXrZulRfj0FNlxjDpRmDEDknvBAXxjHVC0rHOQWPJBaDdRS7Z7M+jcj6onMikY9JZGaKiqsi+7yk/KHW7vXEpg==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0"
+      }
+    },
+    "node_modules/node-opcua-variant": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-variant/-/node-opcua-variant-2.182.0.tgz",
+      "integrity": "sha512-YI9rFFvtv+EMLyoT28i8CGkstrsAGQCYXZaHpqlJx8J+Jmxlgd1bc0h+V8xbe1iRlb0cf4FiIPH3783kDwNCKg==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-basic-types": "2.182.0",
+        "node-opcua-binary-stream": "2.181.0",
+        "node-opcua-data-model": "2.182.0",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-enum": "2.181.0",
+        "node-opcua-factory": "2.182.0",
+        "node-opcua-nodeid": "2.182.0",
+        "node-opcua-utils": "2.181.0"
+      }
+    },
+    "node_modules/node-opcua-vendor-diagnostic": {
+      "version": "2.182.2",
+      "resolved": "https://registry.npmjs.org/node-opcua-vendor-diagnostic/-/node-opcua-vendor-diagnostic-2.182.2.tgz",
+      "integrity": "sha512-qwi0WbhVpD35FbriZ1xxnGNYouVWtCOUkzQxTRGlVmBdoerlXlT0TMkAsW9XzRBT15nYaIYgCqf3r9ZO1T8wog==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize": "0.0.9",
+        "node-opcua-address-space": "2.182.2",
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-constants": "2.181.0",
+        "node-opcua-debug": "2.181.0",
+        "node-opcua-server": "2.182.2",
+        "node-opcua-status-code": "2.181.0",
+        "node-opcua-variant": "2.182.0"
+      }
+    },
+    "node_modules/node-opcua-xml2json": {
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-xml2json/-/node-opcua-xml2json-2.182.0.tgz",
+      "integrity": "sha512-/uJEt5x+nsdE1oxYjVD2TNN+rRbtEY5pd5fb8NflRu/LZ/MIY4Zd0l3tejYOrBjyHHLSIs94dxEOBycKRTfVtg==",
+      "license": "MIT",
+      "dependencies": {
+        "node-opcua-assert": "2.179.0",
+        "node-opcua-utils": "2.181.0",
+        "xml-writer": "^1.7.0"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
+    "node_modules/precond": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha512-QCYG84SgGyGzqJ/vlMsxeXd/pgL/I94ixdNFyh1PusWmTCyVfPJjZ1K1jvHtsbfnXQs2TSkEP2fR7QiMZAnKFQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.2.0.tgz",
+      "integrity": "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sshpk": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sterfive-bonjour-service": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/sterfive-bonjour-service/-/sterfive-bonjour-service-1.1.4.tgz",
+      "integrity": "sha512-QqDpnBb3KLD6ytdY2KSxsynw1jJAvzfOloQt83GQNXO6CGf84ZY+37tpOEZo1FzgUkFiVsL7pYyg71olDppI/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/multicast-dns": "^7.2.1",
+        "array-flatten": "^2.1.2",
+        "dns-equal": "^1.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "multicast-dns": "^7.2.4"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/thenify-ex": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/thenify-ex/-/thenify-ex-4.4.0.tgz",
+      "integrity": "sha512-YHA/2DlY1vWpqGLCc7BzdT9aTrqyHCbsX5J3zbW68LLeD4RPwd+2tMEWshMP+27ikuTnaeKbFDmjqc7fKWmDew==",
+      "license": "MIT"
+    },
+    "node_modules/thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
+    },
+    "node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.9.0.tgz",
+      "integrity": "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg==",
+      "license": "MIT"
+    },
+    "node_modules/webcrypto-core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
+      "integrity": "sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/json-schema": "^1.1.12",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/xml-writer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/xml-writer/-/xml-writer-1.7.0.tgz",
+      "integrity": "sha512-elFVMRiV5jb59fbc87zzVa0C01QLBEWP909mRuWqFqrYC5wNTH5QW4AaKMNv7d6zAsuOulkD7wnztZNLQW0Nfg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/packages/mock-server-aggregate/package.json
+++ b/packages/mock-server-aggregate/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "opcua-mock-aggregate-server",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Aggregate-capable mock OPC UA server used by the end-to-end test suite",
+  "type": "module",
+  "main": "server.mjs",
+  "scripts": {
+    "start": "node server.mjs"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "node-opcua": "^2.128.0",
+    "node-opcua-aggregates": "^2.128.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/packages/mock-server-aggregate/server.mjs
+++ b/packages/mock-server-aggregate/server.mjs
@@ -1,0 +1,84 @@
+/**
+ * Aggregate-capable mock OPC UA server for the end-to-end test suite.
+ *
+ * The bundled Python mock (`packages/mock-server`) deliberately advertises no
+ * aggregate functions, which is what lets the suite assert that both MCP servers
+ * *hide* `read_aggregate_opcua_node` when the server cannot support it. It also
+ * cannot serve aggregates even if it wanted to: python-opcua's history manager
+ * answers `ReadProcessedDetails` with `BadNotImplemented`.
+ *
+ * This server covers the other half. `node-opcua-aggregates` provides a real
+ * `ReadProcessedDetails` implementation and publishes the standard aggregate
+ * function nodes under `ServerCapabilities/AggregateFunctions`, so both MCP
+ * servers expose the aggregate tool against it and compute real values.
+ *
+ * `Temperature` climbs by RAMP_STEP every RAMP_INTERVAL_MS, so aggregates are
+ * verifiable by hand: with a +1.0/second ramp, consecutive Average buckets of
+ * `processing_interval` ms must differ by exactly `processing_interval / 1000`.
+ */
+import { OPCUAServer, DataType, Variant, coerceNodeId } from "node-opcua";
+import { addAggregateSupport } from "node-opcua-aggregates";
+
+const PORT = Number(process.env.AGGREGATE_MOCK_PORT ?? 4841);
+const RESOURCE_PATH = "/UA/Aggregate";
+
+// A deterministic +1.0/second ramp: predictable aggregates, no random walk.
+const RAMP_STEP = 0.5;
+const RAMP_INTERVAL_MS = 500;
+
+const server = new OPCUAServer({
+  port: PORT,
+  resourcePath: RESOURCE_PATH,
+  buildInfo: { productName: "OPC UA Aggregate Mock" },
+});
+
+await server.initialize();
+
+const addressSpace = server.engine.addressSpace;
+addAggregateSupport(addressSpace);
+
+const namespace = addressSpace.getOwnNamespace();
+const plant = namespace.addObject({
+  organizedBy: addressSpace.rootFolder.objects,
+  browseName: "Plant",
+});
+
+let temperature = 20.0;
+const temperatureNode = namespace.addVariable({
+  componentOf: plant,
+  browseName: "Temperature",
+  dataType: "Double",
+  minimumSamplingInterval: RAMP_INTERVAL_MS,
+  value: {
+    get: () => new Variant({ dataType: DataType.Double, value: temperature }),
+  },
+});
+
+addressSpace.installHistoricalDataNode(temperatureNode);
+
+// Advertise historical access the same way the Python mock does, so the history
+// tool is exposed here too and aggregate-vs-raw tool selection can be exercised.
+const historyCapability = addressSpace.findNode(coerceNodeId("ns=0;i=11193"));
+if (historyCapability) {
+  historyCapability.setValueFromSource({
+    dataType: DataType.Boolean,
+    value: true,
+  });
+}
+
+setInterval(() => {
+  temperature += RAMP_STEP;
+  temperatureNode.setValueFromSource({
+    dataType: DataType.Double,
+    value: temperature,
+  });
+}, RAMP_INTERVAL_MS);
+
+await server.start();
+
+// The test fixture waits for this line before connecting. Keep the prefix stable.
+console.log(
+  `READY endpoint=opc.tcp://localhost:${PORT}${RESOURCE_PATH} ` +
+    `nodeId=${temperatureNode.nodeId.toString()} ` +
+    `rampPerSecond=${(RAMP_STEP * 1000) / RAMP_INTERVAL_MS}`,
+);

--- a/packages/server-python/opcua_mcp_server.py
+++ b/packages/server-python/opcua_mcp_server.py
@@ -45,6 +45,7 @@ def _load_contract() -> dict:
 _CONTRACT = _load_contract()
 _DESC = {t["name"]: t["description"] for t in _CONTRACT["tools"]}
 _HISTORY_NODE_ID = _CONTRACT["capabilities"]["history"]["nodeId"]
+_AGGREGATE_NODE_ID = _CONTRACT["capabilities"]["aggregate"]["nodeId"]
 
 # Manage the lifecycle of the OPC UA client connection
 @asynccontextmanager
@@ -160,6 +161,91 @@ def _server_supports_history(url: str) -> bool:
 # Conditionally register the history tool based on server capability.
 if _server_supports_history(server_url):
     read_history_opcua_node = mcp.tool(description=_DESC["read_history_opcua_node"])(read_history_opcua_node)
+
+
+def _server_aggregate_functions(url: str) -> dict[str, ua.NodeId]:
+    """Probe the server's advertised aggregate functions."""
+    try:
+        probe = Client(url)
+        probe.connect()
+        try:
+            aggregate_node = probe.get_node(_AGGREGATE_NODE_ID)
+            aggregate_definitions = {
+                name.removeprefix("AggregateFunction_"): ua.NodeId(identifier, 0)
+                for name, identifier in vars(ua.ObjectIds).items()
+                if name.startswith("AggregateFunction_")
+            }
+            aggregate_functions = {}
+            for child in aggregate_node.get_referenced_nodes(
+                refs=ua.ObjectIds.References,
+                direction=ua.BrowseDirection.Forward,
+            ):
+                try:
+                    browse_name = child.get_browse_name().Name
+                    if (
+                        browse_name in aggregate_definitions
+                        and child.nodeid == aggregate_definitions[browse_name]
+                    ):
+                        aggregate_functions[browse_name] = child.nodeid
+                except Exception:
+                    continue
+            return aggregate_functions
+        finally:
+            probe.disconnect()
+    except Exception:
+        return {}
+
+
+def _server_supports_aggregate(url: str) -> bool:
+    """Probe whether the server advertises aggregate functions."""
+    return bool(_server_aggregate_functions(url))
+
+
+# Conditionally register the aggregate tool based on server capability.
+def read_aggregate_opcua_node(node_id: str,
+                              ctx: Context,
+                              start_time: str,
+                              aggregate_function: str,
+                              end_time: str | None = None,
+                              processing_interval: float = 0) -> list[dict]:
+    """Read processed historical values of a specific OPC UA node."""
+    aggregate_functions = _server_aggregate_functions(server_url)
+    if not aggregate_functions:
+        raise ValueError("Server does not advertise any aggregate functions")
+    if aggregate_function not in aggregate_functions:
+        raise ValueError(
+            "Invalid aggregate function. Supported: "
+            + ", ".join(aggregate_functions)
+        )
+
+    client = ctx.request_context.lifespan_context["opcua_client"]
+    try:
+        details = ua.ReadProcessedDetails()
+        details.StartTime = _parse_iso_datetime(start_time)
+        details.EndTime = _parse_iso_datetime(end_time) or datetime.now()
+        details.ProcessingInterval = processing_interval
+        details.AggregateType = [aggregate_functions[aggregate_function]]
+
+        result = client.get_node(node_id).history_read(details)
+        if not result.StatusCode.is_good():
+            raise ValueError(f"Read aggregate failed with status: {result.StatusCode}")
+
+        return [
+            {
+                "value": str(v.Value.Value),
+                "timestamp": str(v.SourceTimestamp),
+                "status": str(v.StatusCode.name),
+            }
+            for v in result.HistoryData.DataValues
+        ]
+    except Exception as e:
+        raise ValueError(f"Failed to read node {node_id}: {str(e)}")
+
+
+if _server_supports_aggregate(server_url):
+    read_aggregate_opcua_node = mcp.tool(
+        description=_DESC["read_aggregate_opcua_node"]
+    )(read_aggregate_opcua_node)
 
 
 # Tool: Write a value to an OPC UA node

--- a/packages/server-python/opcua_mcp_server.py
+++ b/packages/server-python/opcua_mcp_server.py
@@ -6,7 +6,7 @@ import asyncio
 import os
 import sys
 from typing import List, Dict, Any
-from datetime import datetime
+from datetime import datetime, timezone
 from opcua import ua
 from opcua.ua import NodeClass
 
@@ -222,7 +222,10 @@ def read_aggregate_opcua_node(node_id: str,
     try:
         details = ua.ReadProcessedDetails()
         details.StartTime = _parse_iso_datetime(start_time)
-        details.EndTime = _parse_iso_datetime(end_time) or datetime.now()
+        # UTC, not naive local time: `_parse_iso_datetime` yields aware UTC, so a
+        # naive `datetime.now()` here would shift the window end by the host's UTC
+        # offset and pad the result with an empty bucket per interval in between.
+        details.EndTime = _parse_iso_datetime(end_time) or datetime.now(timezone.utc)
         details.ProcessingInterval = processing_interval
         details.AggregateType = [aggregate_functions[aggregate_function]]
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,6 +11,10 @@ against **both** server implementations.
 | `test_lists_core_tools` | All 7 core tools are advertised |
 | `test_history_tool_exposed_when_supported` | History tool appears because the mock enables history |
 | `test_aggregate_tool_hidden_when_unsupported` | Aggregate tool is **hidden** (mock advertises no aggregate functions) — capability gating |
+| `test_aggregate_tool_exposed_when_supported` | Aggregate tool **appears** against the aggregate-capable mock |
+| `test_aggregate_average_values_are_correct` | `Average` over a known ramp advances by exactly one interval per bucket |
+| `test_aggregate_default_end_time_is_utc` | Omitting `end_time` does not overshoot the window on a non-UTC host (#24) |
+| `test_aggregate_rejects_unknown_function` | An unsupported aggregate name is rejected, listing what the server offers |
 | `test_read_single_node` | `read_opcua_node` returns a value |
 | `test_read_multiple_nodes` | `read_multiple_opcua_nodes` returns all requested nodes |
 | `test_get_all_variables` | `get_all_variables` discovers the address space |
@@ -23,12 +27,26 @@ against **both** server implementations.
 Both servers expose the history tool under the same name, `read_history_opcua_node`,
 and only when the server advertises `AccessHistoryDataCapability`.
 
+## Mock servers
+
+Two are used, on purpose:
+
+| Mock | Port | Role |
+|------|------|------|
+| `packages/mock-server` (python-opcua) | 4840 | Industrial address space, history, methods. Advertises **no** aggregate functions — this is what makes the capability-gating assertions meaningful. |
+| `packages/mock-server-aggregate` (node-opcua) | 4841 | Advertises aggregate functions and genuinely implements `ReadProcessedDetails`. Ramps `Temperature` (`ns=1;i=1001`) by +1.0/second so aggregates are verifiable arithmetically. |
+
+The main mock cannot serve aggregates even in principle: python-opcua answers
+`ReadProcessedDetails` with `BadNotImplemented`.
+
 ## Prerequisites
 
 - `uv`, `node` (>=18), `npm`
 - Set up the workspace once (from the repo root): `uv sync --all-packages`
 - Build the npx server once: `cd packages/server-node && npm install && npm run build`
   (npx tests are **skipped** if `build/index.js` is missing).
+- Install the aggregate mock once: `cd packages/mock-server-aggregate && npm install`
+  (aggregate tests are **skipped** if its `node_modules` is missing).
 
 ## Running
 
@@ -37,12 +55,13 @@ cd tests
 uv run --no-sync pytest -v
 ```
 
-The suite reuses a mock OPC UA server already listening on `:4840`; if none is
-running it starts one for the session (and waits a few seconds for history to
-accumulate). To force a specific endpoint:
+The suite reuses mock OPC UA servers already listening on `:4840` and `:4841`; if
+none is running it starts them for the session (and waits a few seconds for
+history to accumulate). To force specific endpoints:
 
 ```bash
 OPCUA_SERVER_URL="opc.tcp://localhost:4840/freeopcua/server/" uv run --no-sync pytest -v
+OPCUA_AGGREGATE_SERVER_URL="opc.tcp://localhost:4841/UA/Aggregate" uv run --no-sync pytest -v
 ```
 
 Select a single implementation:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,11 @@ The suite drives the *actual* MCP servers (Python and npx) over stdio using the
 official `mcp` client SDK, pointed at the mock industrial OPC UA server. A single
 session-scoped fixture makes sure a mock server is available: if one is already
 listening on :4840 it is reused, otherwise one is started for the test session.
+
+A second, aggregate-capable mock (`packages/mock-server-aggregate`, :4841) backs
+the aggregate tests. It is kept separate from the main mock on purpose: the main
+mock must keep advertising *no* aggregate functions so the suite can assert that
+both MCP servers hide `read_aggregate_opcua_node` when it is unsupported.
 """
 
 from __future__ import annotations
@@ -26,6 +31,23 @@ PORT = 4840
 # Seconds of runtime to allow the mock server to accumulate history before tests
 # read it back. The mock writes one history record per variable per second.
 HISTORY_WARMUP_SECONDS = 6
+
+# --- aggregate-capable mock (packages/mock-server-aggregate) --------------------
+AGGREGATE_PORT = 4841
+AGGREGATE_SERVER_URL = os.environ.get(
+    "OPCUA_AGGREGATE_SERVER_URL", f"opc.tcp://localhost:{AGGREGATE_PORT}/UA/Aggregate"
+)
+AGGREGATE_MOCK_DIR = ROOT / "packages" / "mock-server-aggregate"
+
+# The aggregate mock ramps its Temperature node by a fixed amount every tick, so
+# consecutive Average buckets differ by exactly this much per second of interval.
+AGGREGATE_RAMP_PER_SECOND = 1.0
+# Node ID of that ramping variable, as reported on the server's READY line.
+AGGREGATE_NODE_ID = "ns=1;i=1001"
+
+# The aggregate tests read back windows of up to ~30s, so more warmup is needed
+# here than for the raw-history test against the main mock.
+AGGREGATE_WARMUP_SECONDS = 20
 
 
 def _port_open(host: str, port: int, timeout: float = 0.5) -> bool:
@@ -64,6 +86,54 @@ def opcua_server() -> str:
 
         time.sleep(HISTORY_WARMUP_SECONDS)  # let some history build up
         yield SERVER_URL
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+@pytest.fixture(scope="session")
+def aggregate_opcua_server() -> str:
+    """Ensure the aggregate-capable mock OPC UA server is reachable.
+
+    Reuses an instance already listening on :4841, otherwise starts one for the
+    session. Skips the dependent tests when the mock's dependencies are not
+    installed, mirroring how the npx tests skip on a missing build.
+
+    Yields the server endpoint URL.
+    """
+    if _port_open(HOST, AGGREGATE_PORT):
+        # Something is already serving on :4841 — assume it is the aggregate mock.
+        yield AGGREGATE_SERVER_URL
+        return
+
+    if not (AGGREGATE_MOCK_DIR / "node_modules").is_dir():
+        pytest.skip(
+            "aggregate mock not installed — run `npm install` in "
+            "packages/mock-server-aggregate"
+        )
+
+    proc = subprocess.Popen(
+        ["node", "server.mjs"],
+        cwd=AGGREGATE_MOCK_DIR,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.time() + 60
+        while time.time() < deadline:
+            if _port_open(HOST, AGGREGATE_PORT):
+                break
+            if proc.poll() is not None:
+                raise RuntimeError("aggregate mock OPC UA server exited during startup")
+            time.sleep(1)
+        else:
+            raise RuntimeError("aggregate mock OPC UA server did not start within 60s")
+
+        time.sleep(AGGREGATE_WARMUP_SECONDS)  # let history build up to aggregate over
+        yield AGGREGATE_SERVER_URL
     finally:
         proc.terminate()
         try:

--- a/tests/test_aggregate_e2e.py
+++ b/tests/test_aggregate_e2e.py
@@ -1,0 +1,178 @@
+"""End-to-end tests for `read_aggregate_opcua_node` on both MCP servers.
+
+These run against the aggregate-capable mock (`packages/mock-server-aggregate`,
+:4841) rather than the main mock, which deliberately advertises no aggregate
+functions. The negative case — the tool staying hidden when the server cannot
+support it — lives in ``test_mcp_e2e.py`` and runs against the main mock.
+
+The mock ramps its Temperature node at a known rate, so aggregate output is
+checked arithmetically rather than merely for non-emptiness: with a +1.0/second
+ramp, consecutive Average buckets must differ by exactly the processing interval
+expressed in seconds.
+
+Run:
+    cd tests && uv run pytest -v test_aggregate_e2e.py
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from conftest import AGGREGATE_NODE_ID, AGGREGATE_RAMP_PER_SECOND
+from test_mcp_e2e import NPX_BUILD, _server_params, connect, text_of, tool_names
+
+AGGREGATE_TOOL = "read_aggregate_opcua_node"
+
+# A deliberately non-UTC zone for the regression test below. UTC+5:30 is chosen
+# because it is not a whole number of hours, so a naive-local-time bug cannot be
+# mistaken for an off-by-one-hour DST artefact.
+NON_UTC_TZ = "Asia/Kolkata"
+
+
+@pytest.fixture(params=["python", "npx"])
+def agg_server(request, aggregate_opcua_server):
+    """``(impl_name, StdioServerParameters)`` pointed at the aggregate mock."""
+    impl = request.param
+    if impl == "npx" and not NPX_BUILD.exists():
+        pytest.skip(
+            "npx server not built — run `npm install && npm run build` in "
+            "packages/server-node"
+        )
+    return impl, _server_params(impl, aggregate_opcua_server)
+
+
+# --- helpers -------------------------------------------------------------------
+
+def iso_utc(offset_seconds: int = 0) -> str:
+    """An ISO-8601 UTC timestamp, optionally offset into the past."""
+    moment = datetime.now(timezone.utc) - timedelta(seconds=offset_seconds)
+    return moment.isoformat().replace("+00:00", "Z")
+
+
+def aggregate_values(result, impl: str) -> list[float | None]:
+    """Extract the per-bucket values from an aggregate result.
+
+    The two servers return different shapes for the history family (see #23), so
+    this normalises both to a list of floats with ``None`` for empty buckets.
+    """
+    if impl == "python":
+        values: list[float | None] = []
+        for block in result.content:
+            text = getattr(block, "text", None)
+            if not text or not text.strip().startswith("{"):
+                continue
+            raw = json.loads(text).get("value")
+            values.append(None if raw in (None, "None") else float(raw))
+        return values
+
+    # npx returns a single JSON array of DataValues; empty buckets carry no value.
+    values = []
+    for data_value in json.loads(text_of(result)):
+        raw = (data_value.get("value") or {}).get("value")
+        values.append(None if raw is None else float(raw))
+    return values
+
+
+async def read_average(session, impl, *, window_seconds, interval_ms, end_time="explicit"):
+    """Read Average over the last ``window_seconds``, bucketed by ``interval_ms``."""
+    arguments = {
+        "node_id": AGGREGATE_NODE_ID,
+        "start_time": iso_utc(window_seconds),
+        "aggregate_function": "Average",
+        "processing_interval": interval_ms,
+    }
+    if end_time == "explicit":
+        arguments["end_time"] = iso_utc()
+    result = await session.call_tool(AGGREGATE_TOOL, arguments)
+    return result, aggregate_values(result, impl)
+
+
+# --- tests ---------------------------------------------------------------------
+
+async def test_aggregate_tool_exposed_when_supported(agg_server):
+    """The mock advertises aggregate functions, so both servers must expose the tool."""
+    impl, params = agg_server
+    async with connect(params) as session:
+        names = await tool_names(session)
+    assert AGGREGATE_TOOL in names, f"{impl}: aggregate tool missing despite server support"
+
+
+async def test_aggregate_average_values_are_correct(agg_server):
+    """Averages over a known linear ramp must advance by the interval, in seconds.
+
+    This is the check that actually exercises `ReadProcessedDetails`: a tool that
+    returned records of the wrong node, wrong window, or unaggregated raw history
+    would not produce this exact progression.
+    """
+    impl, params = agg_server
+    interval_ms = 5000
+    async with connect(params) as session:
+        result, values = await read_average(
+            session, impl, window_seconds=20, interval_ms=interval_ms
+        )
+
+    assert not result.isError, text_of(result)
+    populated = [v for v in values if v is not None]
+    assert len(populated) >= 3, f"{impl}: too few populated buckets: {values}"
+
+    # Drop the final bucket: it can be clipped by the end of the window and so
+    # average over a shorter span than the rest.
+    expected_delta = AGGREGATE_RAMP_PER_SECOND * interval_ms / 1000
+    deltas = [round(b - a, 3) for a, b in zip(populated, populated[1:])][:-1]
+    assert deltas, f"{impl}: not enough buckets to compare: {values}"
+    assert all(abs(d - expected_delta) < 0.75 for d in deltas), (
+        f"{impl}: expected ~{expected_delta} per {interval_ms}ms bucket, got {deltas}"
+    )
+
+
+async def test_aggregate_default_end_time_is_utc(agg_server):
+    """Omitting `end_time` must not overshoot the window on a non-UTC host.
+
+    Regression test for #24: the Python server defaulted `EndTime` to a naive
+    local `datetime.now()` while parsing `start_time` as aware UTC, so on a host
+    at UTC+X the window ran X hours into the future and the response was padded
+    with one empty bucket per processing interval in between.
+
+    The server is launched under an explicit non-UTC ``TZ`` so this fails on UTC
+    CI runners too, where the bug would otherwise be invisible.
+    """
+    impl, params = agg_server
+    window_seconds, interval_ms = 60, 10_000
+    skewed = params.model_copy(update={"env": {**(params.env or {}), "TZ": NON_UTC_TZ}})
+
+    async with connect(skewed) as session:
+        result, values = await read_average(
+            session, impl, window_seconds=window_seconds, interval_ms=interval_ms,
+            end_time="default",
+        )
+
+    assert not result.isError, text_of(result)
+    # A 60s window in 10s buckets is 6 buckets, plus at most one for the boundary.
+    # Under the bug this was 727 on a UTC+2 host and would be ~1986 at UTC+5:30.
+    max_buckets = window_seconds * 1000 // interval_ms + 2
+    assert len(values) <= max_buckets, (
+        f"{impl}: default end_time produced {len(values)} buckets for a "
+        f"{window_seconds}s window (expected <= {max_buckets}) — "
+        f"EndTime is likely naive local time rather than UTC"
+    )
+
+
+async def test_aggregate_rejects_unknown_function(agg_server):
+    """An unsupported aggregate name is rejected, listing what the server offers."""
+    impl, params = agg_server
+    async with connect(params) as session:
+        result = await session.call_tool(
+            AGGREGATE_TOOL,
+            {
+                "node_id": AGGREGATE_NODE_ID,
+                "start_time": iso_utc(60),
+                "aggregate_function": "NotAnAggregate",
+                "processing_interval": 10_000,
+            },
+        )
+    text = text_of(result)
+    assert "Invalid aggregate function" in text, f"{impl}: unexpected error: {text}"
+    assert "Average" in text, f"{impl}: supported functions not listed: {text}"

--- a/tests/test_mcp_e2e.py
+++ b/tests/test_mcp_e2e.py
@@ -150,8 +150,11 @@ async def test_history_tool_exposed_when_supported(server):
 
 
 async def test_aggregate_tool_hidden_when_unsupported(server):
-    """The mock server advertises no aggregate functions, so the npx aggregate
-    tool must NOT be exposed (capability gating)."""
+    """The mock server advertises no aggregate functions, so neither server may
+    expose the aggregate tool (capability gating).
+
+    The positive cases live in ``test_aggregate_e2e.py``, which runs against the
+    aggregate-capable mock on :4841."""
     impl, params = server
     async with connect(params) as session:
         names = await tool_names(session)
@@ -161,10 +164,17 @@ async def test_aggregate_tool_hidden_when_unsupported(server):
 async def test_aggregate_direct_call_errors_cleanly(server):
     """Calling read_aggregate_opcua_node directly (no prior tools/list) must not
     crash or wrongly report 'Invalid aggregate function' due to an empty cache —
-    it should recompute support on demand and return a clear message. npx-only."""
+    it should recompute support on demand and return a clear message.
+
+    npx-only by construction. The Python server gates at import time, so against
+    a server without aggregate support the tool is never registered and a direct
+    call returns "Unknown tool" instead. That is a correct MCP response for an
+    unadvertised tool, and the empty-cache failure mode this guards against
+    cannot arise there: the Python server re-probes on every call and holds no
+    cache to be stale."""
     impl, params = server
     if impl != "npx":
-        pytest.skip("aggregate tool is npx-only")
+        pytest.skip("npx-only: the Python server does not register the tool at all here")
     async with connect(params) as session:
         result = await session.call_tool(
             "read_aggregate_opcua_node",


### PR DESCRIPTION
## Summary

This PR adds the `read_aggregate_opcua_node` tool to the Python OPC UA MCP server to bring it in parity with the existing Node.js server.

The new tool allows clients to read processed historical values from an OPC UA node using supported aggregate functions such as Average, Minimum, Maximum, and others.

The tool is only exposed when the OPC UA server advertises aggregate-function support, so servers that do not support aggregates will continue to work as before.

## Type of change

- [ ] Bug fix
- [x] New feature / new tool
- [x] Documentation
- [ ] Refactor / chore

## What changed

- Added aggregate-function capability detection to the Python server.
- Added `read_aggregate_opcua_node` using FreeOpcUa's processed history API.
- Added validation for supported aggregate functions.
- Added error handling for unsupported capabilities and failed aggregate reads.
- Updated the examples documentation to reflect that the tool is available on both servers.

## Testing

Ran the full test suite with:

`uv run --no-sync pytest -v -o asyncio_mode=auto`

Result: **12 passed, 14 skipped**

The skipped tests are related to the Node.js server not being built in the local environment.

## Related issue

Closes #12