### PR TITLE
Unify the history/aggregate response shape across both servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   already *accept* ISO-8601 for `start_time`/`end_time`, so their output now
   round-trips back into their input. (#23)
 
-- **BREAKING (Python server): history values keep their JSON type.** A Double
-  arrives as `51.75`, not `"51.75"`, and an aggregate interval the server holds
-  no data for is `null` rather than the string `"None"`. Values OPC UA can carry
-  but JSON cannot (DateTimes, NodeIds, ExtensionObjects) are still stringified.
-  (#23)
+- **BREAKING (both servers): every OPC UA value type now has one canonical JSON
+  encoding.** A Double arrives as `51.75`, not `"51.75"`, and an aggregate
+  interval the server holds no data for is `null` rather than the string
+  `"None"`. Beyond the primitives, the two client libraries represent the same
+  reading with entirely different native types, so encoding keys on the OPC UA
+  data type rather than the language one — without that, a ByteString was
+  `[97, 98, 99]` from Node and `"b'abc'"` from Python, an Int64 of `-5` was
+  `[4294967295, 4294967291]` from Node and `-5` from Python, and NodeId,
+  StatusCode, DateTime and LocalizedText each had two language-specific
+  spellings.
+
+  ByteString is base64, DateTime is ISO-8601 UTC, Guid is a lower-case UUID,
+  NodeId / StatusCode / QualifiedName / LocalizedText are their canonical text
+  forms, and a 64-bit integer too large for a JSON number (or a non-finite
+  Double) becomes a string rather than being silently rounded. Structured and
+  opaque types (ExtensionObject, XmlElement) still degrade to a string form that
+  may differ between runtimes.
+
+  `tests/fixtures/value-encoding.json` holds the table; both unit suites build
+  the native value for every case and assert the same JSON comes out, so a case
+  cannot be added without both runtimes handling it. (#23)
 
 ### Fixed
 - Corrected the READMEs for the published packages: the PyPI long description

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING (Node server): `read_history_opcua_node` and
+  `read_aggregate_opcua_node` now return flat records instead of raw
+  `DataValue` JSON.** The two servers answered the same tool call with different
+  shapes — the Node server with node-opcua's internal representation
+  (`{"value": {"dataType": "Double", "value": 51.75}, "statusCode": {"value": 1},
+  "sourceTimestamp": …}`), the Python server with `{value, timestamp, status}`.
+  Both were "correct": `contract/tools.json` unified tool names, descriptions and
+  capability gating, but said nothing about output. A client — or a model — that
+  learned one server's output misread the other's.
+
+  The contract now declares the shape, under `resultShapes.historyRecords`, and
+  both servers produce it:
+
+  ```json
+  { "value": 51.75, "timestamp": "2026-09-09T13:36:01.139Z", "status": "Good" }
+  ```
+
+  One record per historical value or aggregate interval, one MCP content block
+  per record. Anything consuming the Node server's `sourceTimestamp` /
+  `statusCode.value` / nested `value.value` must move to `timestamp` / `status` /
+  `value`. (#23)
+
+- **BREAKING (Python server): history timestamps are ISO-8601 UTC**, e.g.
+  `2026-09-09T13:36:01.468091Z` rather than `str(datetime)`'s
+  `2026-09-09 13:36:01.468000` — space-separated and with no zone. The same tools
+  already *accept* ISO-8601 for `start_time`/`end_time`, so their output now
+  round-trips back into their input. (#23)
+
+- **BREAKING (Python server): history values keep their JSON type.** A Double
+  arrives as `51.75`, not `"51.75"`, and an aggregate interval the server holds
+  no data for is `null` rather than the string `"None"`. Values OPC UA can carry
+  but JSON cannot (DateTimes, NodeIds, ExtensionObjects) are still stringified.
+  (#23)
+
 ### Fixed
 - Corrected the READMEs for the published packages: the PyPI long description
   claimed Python 3.13+ (the floor is 3.10), had no install instructions for the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,9 +90,10 @@ agent, see **[docs/testing.md](docs/testing.md)**.
 The tool surface is defined once in [`contract/tools.json`](contract/tools.json); both servers derive from it, and `tests/test_contract_parity.py` fails if they diverge. To add a tool `foo`:
 
 1. **Contract** (`contract/tools.json`): add an entry under `tools` with its `name`, `description`, `inputSchema` (JSON Schema), and `capability` (`null`, or `"history"`/`"aggregate"` if it depends on a server capability).
+   If the tool returns structured data rather than free text, give it a `resultShape` naming an entry under `resultShapes` — reuse an existing shape where one fits. Both servers must then emit that shape byte-comparably; a client that has learned one server's output has to be able to read the other's, and `tests/e2e/test_contract_parity.py` checks the real output against the shape.
 2. **Node** (`packages/server-node/src/tools.ts`): add a `case "foo"` to the `callTool` switch and implement the handler method. You do **not** edit `listTools` — it is generated from the contract. Run `npm run build` (this also stages the contract and version into `build/`).
 3. **Python** (`packages/server-python/src/opcua_mcp_server/server.py`): add a function decorated with `@mcp.tool(description=_DESC["foo"])`, with typed args (FastMCP derives the input schema from them — keep it matching the contract) and `ctx: Context`. For a capability-gated tool, register it conditionally like `read_history_opcua_node`.
-4. **Test**: add an end-to-end test in `tests/e2e/test_mcp_e2e.py` (it runs against both servers). The contract-parity test will automatically check that both servers advertise the new tool with the contract's description and parameters.
+4. **Test**: add an end-to-end test in `tests/e2e/test_mcp_e2e.py` (it runs against both servers). The contract-parity test will automatically check that both servers advertise the new tool with the contract's description and parameters; if the tool declares a `resultShape`, assert the returned records against it with `assert_matches_result_shape`.
 5. **Document it** in `docs/examples.md` (the central per-tool reference).
 
 ## Code style

--- a/README.md
+++ b/README.md
@@ -134,10 +134,14 @@ get_all_variables
   …
 
 read_history_opcua_node  node_id="ns=2;i=3"  num_values=2
-→ [ { "value": { "dataType": "Double", "value": 23.198876064466138 },
-      "statusCode": { "value": 0 },
-      "sourceTimestamp": "2026-09-09T21:11:09.043Z" }, … ]
+→ { "value": 24.231991377989036, "timestamp": "2026-09-10T13:15:12.214Z", "status": "Good" }
+  { "value": 26.089859958260515, "timestamp": "2026-09-10T13:15:11.208Z", "status": "Good" }
 ```
+
+Both runtimes return that same record shape — one record per historical value —
+for `read_history_opcua_node` and `read_aggregate_opcua_node` alike. It is
+defined in `contract/tools.json` (`resultShapes.historyRecords`) and enforced
+against both servers by the test suite.
 
 Bad input is rejected identically by both runtimes:
 

--- a/contract/tools.json
+++ b/contract/tools.json
@@ -1,5 +1,30 @@
 {
-  "$comment": "Single source of truth for the OPC UA MCP tool surface shared by both servers. The Node server builds its tools/list response directly from this file (copied into build/ at build time). The Python (FastMCP) server reads tool descriptions and the capability node IDs from it; its signature-derived input schemas are checked against this file by tests/test_contract_parity.py. To add or change a tool: edit this file, then update each server's per-tool logic (Node: a case in the CallTool switch; Python: the @mcp.tool function), and add an E2E test.",
+  "$comment": "Single source of truth for the OPC UA MCP tool surface shared by both servers. The Node server builds its tools/list response directly from this file (copied into build/ at build time). The Python (FastMCP) server reads tool descriptions and the capability node IDs from it; its signature-derived input schemas are checked against this file by tests/test_contract_parity.py. To add or change a tool: edit this file, then update each server's per-tool logic (Node: a case in the CallTool switch; Python: the @mcp.tool function), and add an E2E test. A tool whose output is more than free text also names a shape from \"resultShapes\"; tests/e2e/test_contract_parity.py checks both servers' actual output against it.",
+  "resultShapes": {
+    "$comment": "Canonical response shapes, referenced by a tool's \"resultShape\". Both servers must produce the referenced shape verbatim: a client (or a model) that learns one server's output must be able to read the other's. See issue #23.",
+    "historyRecords": {
+      "$comment": "Returned as one MCP text content block per record, each block the JSON object described by \"items\". An empty result is zero blocks. The Python server additionally returns the array as structured content.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "description": "The recorded value: JSON-native when the OPC UA type maps onto JSON (number, boolean, string, or an array of those), otherwise its string form. null for an interval the server holds no data for."
+          },
+          "timestamp": {
+            "type": ["string", "null"],
+            "description": "Source timestamp, ISO-8601 UTC with a trailing 'Z'. Example: '2026-09-09T13:36:01.468Z'. null when the server supplied none."
+          },
+          "status": {
+            "type": "string",
+            "description": "OPC UA status code name. Examples: 'Good', 'BadNoData'."
+          }
+        },
+        "required": ["value", "timestamp", "status"],
+        "additionalProperties": false
+      }
+    }
+  },
   "capabilities": {
     "history": {
       "nodeId": "ns=0;i=11193",
@@ -137,6 +162,7 @@
     },
     {
       "name": "read_history_opcua_node",
+      "resultShape": "historyRecords",
       "capability": "history",
       "description": "Read the historical values of a specific OPC UA node",
       "inputSchema": {
@@ -164,6 +190,7 @@
     },
     {
       "name": "read_aggregate_opcua_node",
+      "resultShape": "historyRecords",
       "capability": "aggregate",
       "description": "Calculate the historical aggregates over a defined time range, divided into smaller chunks defined by the `processing_interval` (in milliseconds). The server divides the [`start_time`, `end_time`] domain into these intervals, returning one aggregated value per interval",
       "inputSchema": {

--- a/contract/tools.json
+++ b/contract/tools.json
@@ -9,7 +9,7 @@
         "type": "object",
         "properties": {
           "value": {
-            "description": "The recorded value: JSON-native when the OPC UA type maps onto JSON (number, boolean, string, or an array of those), otherwise its string form. null for an interval the server holds no data for."
+            "description": "The recorded value, encoded per its OPC UA data type: numbers, booleans and strings stay themselves; a ByteString is base64; a DateTime is ISO-8601 UTC; a Guid is a lower-case UUID; NodeId, StatusCode, QualifiedName and LocalizedText are their canonical text forms; an Int64/UInt64 outside the range a JSON number can hold exactly, and a non-finite Double, become strings (\"9007199254740993\", \"NaN\"); an array value is a JSON array of those. null for an interval the server holds no data for. The full table, and the fact that both servers produce the same encoding for the same reading, is pinned by tests/fixtures/value-encoding.json."
           },
           "timestamp": {
             "type": ["string", "null"],

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,10 +26,20 @@ That interchangeability is not maintained by discipline. It is maintained by
 | **Node** | Builds its `tools/list` response directly from it. `npm run build` copies it to `build/contract.json` so the npm package is self-contained. |
 | **Python** | Reads tool descriptions and capability node IDs from it. Input schemas are derived by FastMCP from the function signatures, and checked against the contract by a test. |
 
+The contract also pins what the tools *return*, where the answer is more than
+free text. A tool names a shape from `resultShapes`; the history family
+(`read_history_opcua_node`, `read_aggregate_opcua_node`) shares
+`historyRecords`, one flat `{value, timestamp, status}` record per historical
+value or aggregate interval. That was the second half of interchangeability, and
+for a while it was missing: both servers matched on names and parameters but the
+Node one returned raw `node-opcua` `DataValue` JSON while the Python one returned
+flat records, so a client that learned one misread the other.
+
 `tests/e2e/test_contract_parity.py` starts both servers and asserts each
 advertises exactly the contract's applicable tools, with matching descriptions
-and parameter sets. `tests/unit/test_contract.py` checks the contract file itself
-is well-formed.
+and parameter sets, and that what each actually returns satisfies the declared
+`resultShape`. `tests/unit/test_contract.py` checks the contract file itself is
+well-formed.
 
 **Adding a tool** therefore means editing the contract, adding the per-tool logic
 in each runtime, and adding a test — see [CONTRIBUTING.md](../CONTRIBUTING.md).
@@ -82,9 +92,9 @@ the repo.
 contract/tools.json          single source of truth for the tool surface
 packages/server-python/      FastMCP + opcua (FreeOpcUa)
   src/opcua_mcp_server/      config · contract · datetimes · capabilities
-                             · aggregates · server
+                             · aggregates · records · server
 packages/server-node/        @modelcontextprotocol/sdk + node-opcua
-  src/                       config · contract · dates · connection
+  src/                       config · contract · dates · records · connection
                              · tools · index
 packages/mock-server/        simulated PLC/sensors (:4840, no aggregates)
 packages/mock-server-aggregate/  aggregate-capable mock (:4841)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,7 +30,13 @@ The contract also pins what the tools *return*, where the answer is more than
 free text. A tool names a shape from `resultShapes`; the history family
 (`read_history_opcua_node`, `read_aggregate_opcua_node`) shares
 `historyRecords`, one flat `{value, timestamp, status}` record per historical
-value or aggregate interval. That was the second half of interchangeability, and
+value or aggregate interval. The `value` encoding keys on the OPC UA data type
+rather than the language one — python-opcua and node-opcua represent the same
+reading with entirely different native types (a ByteString is `bytes` vs a
+`Buffer`, an Int64 a plain int vs a `[high, low]` pair), so anything reaching for
+the runtime type diverges by construction. `tests/fixtures/value-encoding.json`
+is the shared table, and both unit suites build the native value for every case
+in it and assert the same JSON comes out. That was the second half of interchangeability, and
 for a while it was missing: both servers matched on names and parameters but the
 Node one returned raw `node-opcua` `DataValue` JSON while the Python one returned
 flat records, so a client that learned one misread the other.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -165,7 +165,7 @@ as one content block each:
 
 | Field | Meaning |
 |---|---|
-| `value` | The recorded value, JSON-native where the OPC UA type allows (a number stays a number). `null` for an interval with no data. |
+| `value` | The recorded value, encoded per its OPC UA data type — a number stays a number, a ByteString is base64, a DateTime is ISO-8601 UTC, a NodeId is `ns=2;i=3`. `null` for an interval with no data. The full table is `../tests/fixtures/value-encoding.json`. |
 | `timestamp` | Source timestamp, ISO-8601 UTC — the same format `start_time`/`end_time` accept. |
 | `status` | OPC UA status code name, e.g. `Good`, `BadNoData`. |
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -151,24 +151,30 @@ functions (so the aggregate tool stays hidden).
 Read recorded historical values for a node. Exposed only when the server
 advertises `AccessHistoryDataCapability`.
 
-Python:
-```json
-{ "node_id": "ns=2;i=3", "num_values": 3 }
-```
-```json
-[ { "value": "26.01", "timestamp": "2026-06-05 09:55:03.382152", "status": "Good" } ]
-```
-
-Node (also accepts ISO-8601 `start_time`/`end_time`):
 ```json
 { "node_id": "ns=2;i=3", "start_time": "2026-06-05T09:50:00Z",
   "end_time": "2026-06-05T10:30:00Z", "num_values": 3 }
 ```
+
+Both servers answer with the same records — one per historical value, returned
+as one content block each:
+
 ```json
-[ { "value": { "dataType": "Double", "value": 25 },
-    "statusCode": { "value": 0 },
-    "sourceTimestamp": "2026-06-05T09:53:40.950Z" } ]
+{ "value": 26.01, "timestamp": "2026-06-05T09:55:03.382Z", "status": "Good" }
 ```
+
+| Field | Meaning |
+|---|---|
+| `value` | The recorded value, JSON-native where the OPC UA type allows (a number stays a number). `null` for an interval with no data. |
+| `timestamp` | Source timestamp, ISO-8601 UTC — the same format `start_time`/`end_time` accept. |
+| `status` | OPC UA status code name, e.g. `Good`, `BadNoData`. |
+
+The shape is defined once, in `../contract/tools.json` under
+`resultShapes.historyRecords`, and both servers are held to it by
+`../tests/e2e/test_contract_parity.py`. Earlier versions of the Node server
+returned raw `DataValue` JSON here instead
+(`{"statusCode": {"value": 0}, "sourceTimestamp": …}`); see `../CHANGELOG.md`.
+
 > Prompt: *"Show the last 5 temperature readings from history."*
 
 ### `read_aggregate_opcua_node`
@@ -179,6 +185,14 @@ functions** — the bundled mock does not, so this tool is not exposed against i
 { "node_id": "ns=2;i=3", "start_time": "2026-06-05T09:50:00Z",
   "aggregate_function": "Average", "processing_interval": 60000 }
 ```
+
+The result uses the same record shape as `read_history_opcua_node` above, one
+record per interval:
+
+```json
+{ "value": 25.83, "timestamp": "2026-06-05T09:50:00.000Z", "status": "Good" }
+```
+
 > Prompt: *"What was the average temperature per minute over the last hour?"*
 
 ---

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -73,7 +73,7 @@ Things to try:
 |------|-----------|----------|
 | `read_opcua_node` | `node_id` = `ns=2;i=3` | `Node ns=2;i=3 value: 26.x` |
 | `get_all_variables` | *(none)* | `Found 22 variables: …` |
-| `read_history_opcua_node` | `node_id` = `ns=2;i=3`, `num_values` = `5` | array of 5 timestamped records, status `Good` |
+| `read_history_opcua_node` | `node_id` = `ns=2;i=3`, `num_values` = `5` | 5 records of `{ value, timestamp, status }`, status `Good`, ISO-8601 UTC timestamps — identical on both servers |
 | `read_history_opcua_node` | `node_id` = `ns=2;i=3`, `start_time` = `2026-01-01T00:00:00Z` | records within the window |
 | `read_history_opcua_node` | `node_id` = `ns=2;i=3`, `start_time` = `nope` | clear error: *Use ISO 8601…* |
 | `write_opcua_node` | `node_id` = `ns=2;i=13`, `value` = `80` | `Successfully wrote 80…` |

--- a/packages/server-node/src/records.ts
+++ b/packages/server-node/src/records.ts
@@ -1,0 +1,73 @@
+// The canonical record shape for the history family of tools.
+//
+// `contract/tools.json` -> resultShapes.historyRecords is the specification;
+// this module is the Node implementation of it, and `records.py` in the Python
+// server is the other. Both servers must emit byte-comparable records: a client
+// — or a model — that has learned one server's output has to be able to read the
+// other's. This file previously did not exist; the Node server returned raw
+// node-opcua `DataValue` JSON (`{"statusCode":{"value":1},"sourceTimestamp":…}`)
+// while the Python server returned flat records. See issue #23.
+import { DataValue } from "node-opcua";
+
+export interface HistoryRecord {
+  /** JSON-native when the OPC UA type maps onto JSON, else its string form. */
+  value: unknown;
+  /** ISO-8601 UTC with a trailing `Z`, or null when the server supplied none. */
+  timestamp: string | null;
+  /** OPC UA status code name, e.g. `Good` / `BadNoData`. */
+  status: string;
+}
+
+/** An OPC UA value as JSON, without the Variant wrapper.
+ *
+ * Values that JSON can carry (number, boolean, string, and arrays of those) pass
+ * through as themselves, so a consumer gets `51.75` rather than `"51.75"`.
+ * Anything else — a DateTime, a NodeId, an ExtensionObject — becomes its string
+ * form, which is lossy but always serialisable; returning it raw would leak
+ * node-opcua's internal representation back into the response.
+ */
+export function toJsonValue(value: unknown): unknown {
+  if (value === null || value === undefined) return null;
+
+  switch (typeof value) {
+    case "boolean":
+    case "string":
+      return value;
+    // NaN and ±Infinity are not JSON; JSON.stringify would silently emit `null`
+    // and lose the distinction between "no data" and "not a number".
+    case "number":
+      return Number.isFinite(value) ? value : String(value);
+    case "bigint":
+      return Number.isSafeInteger(Number(value)) ? Number(value) : value.toString();
+  }
+
+  // Typed arrays (Float64Array & friends) are how node-opcua carries array
+  // variants; Array.from normalises them to a plain array.
+  if (Array.isArray(value) || ArrayBuffer.isView(value)) {
+    return Array.from(value as ArrayLike<unknown>, toJsonValue);
+  }
+  if (value instanceof Date) return value.toISOString();
+
+  return String(value);
+}
+
+/** A timestamp as ISO-8601 UTC, mirroring the Python server's `format_iso_utc`. */
+export function toIsoUtc(value: Date | null | undefined): string | null {
+  if (!(value instanceof Date) || isNaN(value.getTime())) return null;
+  return value.toISOString();
+}
+
+/** One `DataValue` as a canonical record. */
+export function toHistoryRecord(dataValue: DataValue): HistoryRecord {
+  return {
+    value: toJsonValue(dataValue?.value?.value),
+    timestamp: toIsoUtc(dataValue?.sourceTimestamp),
+    // An absent status code means Good in OPC UA, so say so rather than null.
+    status: dataValue?.statusCode?.name ?? "Good",
+  };
+}
+
+/** The history/aggregate `DataValue` array as canonical records. */
+export function toHistoryRecords(dataValues: DataValue[] | null | undefined): HistoryRecord[] {
+  return (dataValues ?? []).map(toHistoryRecord);
+}

--- a/packages/server-node/src/records.ts
+++ b/packages/server-node/src/records.ts
@@ -2,15 +2,21 @@
 //
 // `contract/tools.json` -> resultShapes.historyRecords is the specification;
 // this module is the Node implementation of it, and `records.py` in the Python
-// server is the other. Both servers must emit byte-comparable records: a client
-// — or a model — that has learned one server's output has to be able to read the
-// other's. This file previously did not exist; the Node server returned raw
-// node-opcua `DataValue` JSON (`{"statusCode":{"value":1},"sourceTimestamp":…}`)
-// while the Python server returned flat records. See issue #23.
-import { DataValue } from "node-opcua";
+// server is the other. Both servers must emit the same record for the same
+// reading: a client — or a model — that has learned one server's output has to
+// be able to read the other's. See issue #23.
+//
+// Conversion keys on the OPC UA *data type*, not on the JavaScript runtime type.
+// That is not incidental. The two client libraries represent the same OPC UA
+// value with wildly different native types — a ByteString is a Buffer here and
+// `bytes` in Python, an Int64 is a [high, low] pair here and a plain int in
+// Python — so anything that reaches for `String(value)` or `typeof` as its
+// primary signal diverges by construction. The per-type table is shared, and
+// pinned from both sides by tests/fixtures/value-encoding.json.
+import { DataType, DataValue, Variant, VariantArrayType } from "node-opcua";
 
 export interface HistoryRecord {
-  /** JSON-native when the OPC UA type maps onto JSON, else its string form. */
+  /** JSON-native where the OPC UA type allows; see `variantToJson`. */
   value: unknown;
   /** ISO-8601 UTC with a trailing `Z`, or null when the server supplied none. */
   timestamp: string | null;
@@ -18,37 +24,120 @@ export interface HistoryRecord {
   status: string;
 }
 
-/** An OPC UA value as JSON, without the Variant wrapper.
+/** Past this, a JSON number silently loses digits in any JS parser. */
+const MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER);
+
+/** The OPC UA type name (`"Double"`, `"ByteString"`, …) both runtimes key on. */
+function typeName(dataType: DataType | undefined | null): string {
+  return dataType === undefined || dataType === null ? "" : (DataType[dataType] ?? "");
+}
+
+/** A 64-bit integer as a JSON number, or a decimal string when it cannot be one.
  *
- * Values that JSON can carry (number, boolean, string, and arrays of those) pass
- * through as themselves, so a consumer gets `51.75` rather than `"51.75"`.
- * Anything else — a DateTime, a NodeId, an ExtensionObject — becomes its string
- * form, which is lossy but always serialisable; returning it raw would leak
- * node-opcua's internal representation back into the response.
+ * Both servers switch to a string at the same threshold, so neither rounds a
+ * counter or a serial number behind the caller's back.
  */
-export function toJsonValue(value: unknown): unknown {
+function bigIntToJson(value: bigint): number | string {
+  return value >= -MAX_SAFE && value <= MAX_SAFE ? Number(value) : value.toString();
+}
+
+/** An Int64/UInt64, which node-opcua carries as a [high, low] pair of halves.
+ *
+ * A JS number cannot hold the full 64-bit range, so node-opcua splits it in two.
+ * python-opcua hands over a plain int, so without this the same reading is `-5`
+ * on one server and `[4294967295, 4294967291]` on the other.
+ */
+function int64ToJson(value: unknown, signed: boolean): unknown {
+  let big: bigint;
+
+  if (Array.isArray(value) && value.length === 2) {
+    const [high, low] = value as [number, number];
+    big = (BigInt(high >>> 0) << 32n) | BigInt(low >>> 0);
+    big = signed ? BigInt.asIntN(64, big) : BigInt.asUintN(64, big);
+  } else if (typeof value === "bigint") {
+    big = value;
+  } else if (typeof value === "number") {
+    return Number.isFinite(value) ? value : String(value);
+  } else {
+    return String(value);
+  }
+
+  return bigIntToJson(big);
+}
+
+/** One scalar OPC UA value as JSON, given its data type. */
+function scalarToJson(value: unknown, dataType: DataType | undefined | null): unknown {
   if (value === null || value === undefined) return null;
+
+  // Types whose native representation differs between the two client libraries.
+  // NodeId, ExpandedNodeId and QualifiedName are absent on purpose: node-opcua
+  // already stringifies those to their canonical `ns=2;i=3` / `2:Name` forms,
+  // which is what the Python server produces too.
+  switch (typeName(dataType)) {
+    case "Int64":
+      return int64ToJson(value, true);
+    case "UInt64":
+      return int64ToJson(value, false);
+    case "ByteString":
+      return Buffer.isBuffer(value) ? value.toString("base64") : String(value);
+    case "DateTime":
+      return toIsoUtc(value as Date) ?? String(value);
+    case "Guid":
+      // Lower case: the RFC 4122 canonical form, and what Python's UUID renders.
+      return String(value).toLowerCase();
+    case "StatusCode":
+      return (value as { name?: string }).name ?? String(value);
+    case "LocalizedText":
+      // The text only; the locale is not part of the reading.
+      return (value as { text?: string | null }).text ?? "";
+  }
 
   switch (typeof value) {
     case "boolean":
     case "string":
       return value;
-    // NaN and ±Infinity are not JSON; JSON.stringify would silently emit `null`
-    // and lose the distinction between "no data" and "not a number".
     case "number":
+      // NaN and ±Infinity are not JSON; JSON.stringify would silently emit
+      // `null` and lose the distinction between "no data" and "not a number".
       return Number.isFinite(value) ? value : String(value);
     case "bigint":
-      return Number.isSafeInteger(Number(value)) ? Number(value) : value.toString();
+      return bigIntToJson(value);
   }
 
-  // Typed arrays (Float64Array & friends) are how node-opcua carries array
-  // variants; Array.from normalises them to a plain array.
+  // Fallbacks for a value that arrived without a usable data type.
+  if (value instanceof Date) return toIsoUtc(value) ?? String(value);
+  if (Buffer.isBuffer(value)) return value.toString("base64");
   if (Array.isArray(value) || ArrayBuffer.isView(value)) {
-    return Array.from(value as ArrayLike<unknown>, toJsonValue);
+    return Array.from(value as ArrayLike<unknown>, (item) => scalarToJson(item, dataType));
   }
-  if (value instanceof Date) return value.toISOString();
 
+  // Structured and opaque types (ExtensionObject, XmlElement, …) degrade to a
+  // string. Those are not the shape of anything a server historises as a
+  // variable value, and a faithful cross-runtime encoding of them would be a
+  // much larger undertaking than this record is worth.
   return String(value);
+}
+
+/** An OPC UA value as JSON, without the Variant wrapper.
+ *
+ * Values that JSON can carry pass through as themselves, so a consumer gets
+ * `51.75` rather than `"51.75"`. Everything else follows the per-type table in
+ * `scalarToJson`.
+ */
+export function variantToJson(variant: Variant | null | undefined): unknown {
+  if (!variant) return null;
+
+  const { value, dataType, arrayType } = variant;
+  if (value === null || value === undefined) return null;
+
+  // Array-ness comes from the variant, never from the runtime type: a *scalar*
+  // Int64 is itself a two-element array, and a scalar ByteString is a Buffer,
+  // so `Array.isArray` / `ArrayBuffer.isView` would split both down the middle.
+  if (arrayType !== undefined && arrayType !== VariantArrayType.Scalar) {
+    return Array.from(value as ArrayLike<unknown>, (item) => scalarToJson(item, dataType));
+  }
+
+  return scalarToJson(value, dataType);
 }
 
 /** A timestamp as ISO-8601 UTC, mirroring the Python server's `format_iso_utc`. */
@@ -60,7 +149,7 @@ export function toIsoUtc(value: Date | null | undefined): string | null {
 /** One `DataValue` as a canonical record. */
 export function toHistoryRecord(dataValue: DataValue): HistoryRecord {
   return {
-    value: toJsonValue(dataValue?.value?.value),
+    value: variantToJson(dataValue?.value),
     timestamp: toIsoUtc(dataValue?.sourceTimestamp),
     // An absent status code means Good in OPC UA, so say so rather than null.
     status: dataValue?.statusCode?.name ?? "Good",

--- a/packages/server-node/src/tools.ts
+++ b/packages/server-node/src/tools.ts
@@ -20,6 +20,23 @@ import { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { OpcuaConnection } from "./connection.js";
 import { CONTRACT } from "./contract.js";
 import { toDate } from "./dates.js";
+import { toHistoryRecords } from "./records.js";
+
+/** A history/aggregate response: one text block per canonical record.
+ *
+ * The framing is part of the contract (resultShapes.historyRecords), not an
+ * implementation detail: FastMCP splits the Python server's returned list into
+ * one block per element, so the Node server does the same rather than emitting a
+ * single array — the two servers' responses are then read the same way.
+ */
+function historyResult(dataValues: DataValue[] | null | undefined) {
+  return {
+    content: toHistoryRecords(dataValues).map((record) => ({
+      type: "text",
+      text: JSON.stringify(record, null, 2),
+    })),
+  };
+}
 
 export class OpcuaTools {
   private aggregateFunctions: string[] = [];
@@ -199,14 +216,7 @@ export class OpcuaTools {
         );
       }
       const dataValues = (historyValues[0].historyData as HistoryData).dataValues;
-      return {
-        content: [
-          {
-            type: "text",
-            text: `${JSON.stringify(dataValues, null, 2)}`,
-          },
-        ],
-      };
+      return historyResult(dataValues);
     } catch (error) {
       throw new Error(
         `Failed to read node ${nodeId}: ${error instanceof Error ? error.message : String(error)}`
@@ -254,14 +264,7 @@ export class OpcuaTools {
         );
       }
       const dataValues = (historyValues.historyData as HistoryData).dataValues;
-      return {
-        content: [
-          {
-            type: "text",
-            text: `${JSON.stringify(dataValues, null, 2)}`,
-          },
-        ],
-      };
+      return historyResult(dataValues);
     } catch (error) {
       throw new Error(
         `Failed to read node ${nodeId}: ${error instanceof Error ? error.message : String(error)}`

--- a/packages/server-node/test/unit.test.mjs
+++ b/packages/server-node/test/unit.test.mjs
@@ -8,9 +8,19 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import test, { describe } from "node:test";
 import { fileURLToPath } from "node:url";
+import {
+  DataType,
+  LocalizedText,
+  NodeId,
+  QualifiedName,
+  StatusCodes,
+  Variant,
+  VariantArrayType,
+  coerceNodeId,
+} from "node-opcua";
 
 import { toDate } from "../build/dates.js";
-import { toHistoryRecords, toIsoUtc, toJsonValue } from "../build/records.js";
+import { toHistoryRecords, toIsoUtc, variantToJson } from "../build/records.js";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -77,27 +87,107 @@ describe("toDate", () => {
 });
 
 // The canonical history-family record shape (contract -> resultShapes.historyRecords).
-// The Python server's equivalent tests are in tests/unit/test_records.py; both
-// assert the same shape, because a client must be able to read either server.
+// The Python equivalents are in tests/unit/test_records.py.
+//
+// The per-type value encoding is not restated here — it lives in
+// tests/fixtures/value-encoding.json, which both suites read. Each side builds
+// the *native* value for a case (that is the whole problem: a Buffer here,
+// `bytes` there) and asserts the same JSON comes out.
+const FIXTURE = JSON.parse(
+  readFileSync(join(ROOT, "..", "..", "tests", "fixtures", "value-encoding.json"), "utf8")
+);
+const CASES = Object.fromEntries(FIXTURE.cases.map((c) => [c.name, c]));
+
+const scalar = (dataType, value) => new Variant({ dataType, value });
+// Int64/UInt64 need an explicit arrayType: their scalar form is itself a
+// [high, low] pair, so node-opcua refuses to guess whether an array is one
+// value or many. That ambiguity is exactly why the encoder keys on the variant.
+const int64 = (dataType, value) =>
+  new Variant({ dataType, arrayType: VariantArrayType.Scalar, value });
+const array = (dataType, value) =>
+  new Variant({ dataType, arrayType: VariantArrayType.Array, value });
+
+// The native node-opcua value for each case in the fixture. The Python suite has
+// its own table of the same names holding python-opcua values; the two produce
+// the same JSON, which is the point.
+const NATIVE = {
+  boolean: scalar(DataType.Boolean, true),
+  int32: scalar(DataType.Int32, 42),
+  int64_small: int64(DataType.Int64, 5),
+  int64_negative: int64(DataType.Int64, -5),
+  int64_beyond_double: int64(DataType.Int64, [0x200000, 1]), // 2^53 + 1, exact only as a pair
+  uint64_max: int64(DataType.UInt64, [0xffffffff, 0xffffffff]),
+  double: scalar(DataType.Double, 51.75),
+  double_nan: scalar(DataType.Double, NaN),
+  double_infinity: scalar(DataType.Double, Infinity),
+  string: scalar(DataType.String, "AUTO"),
+  datetime: scalar(DataType.DateTime, new Date("2026-09-09T13:36:01.468Z")),
+  guid: scalar(DataType.Guid, "72962B91-FA75-4AE6-8D28-B404DC7DAF63"),
+  bytestring: scalar(DataType.ByteString, Buffer.from("abc")),
+  nodeid: scalar(DataType.NodeId, coerceNodeId("ns=2;i=3")),
+  statuscode: scalar(DataType.StatusCode, StatusCodes.Good),
+  qualifiedname: scalar(
+    DataType.QualifiedName,
+    new QualifiedName({ name: "Temperature", namespaceIndex: 2 })
+  ),
+  localizedtext: scalar(DataType.LocalizedText, new LocalizedText({ text: "Ambient temperature" })),
+  double_array: array(DataType.Double, [1.5, 2.5]),
+  byte_array: array(DataType.Byte, [97, 98, 99]),
+  int64_array: array(DataType.Int64, [5, [0x200000, 1]]),
+  bytestring_array: array(DataType.ByteString, [Buffer.from("ab"), Buffer.from("c")]),
+  empty_array: array(DataType.Double, []),
+  null: scalar(DataType.Null, null),
+};
+
+describe("value encoding (shared fixture)", () => {
+  test("every fixture case has a native value", () => {
+    // A case with no entry above would pass by never being run.
+    assert.deepEqual(Object.keys(NATIVE).sort(), Object.keys(CASES).sort());
+  });
+
+  for (const [name, expectation] of Object.entries(CASES)) {
+    test(`${name} matches the shared fixture`, () => {
+      const encoded = variantToJson(NATIVE[name]);
+      if (expectation.expectedPattern) {
+        assert.match(String(encoded), new RegExp(expectation.expectedPattern));
+      } else {
+        assert.deepEqual(encoded, expectation.expected);
+      }
+    });
+  }
+
+  // Regression guards for the divergences that prompted the shared fixture:
+  // node-opcua splits an Int64 into a [high, low] pair and carries a ByteString
+  // as a Buffer, neither of which resembles what python-opcua hands over.
+  test("an Int64 is a number, not node-opcua's [high, low] pair", () => {
+    assert.equal(variantToJson(NATIVE.int64_negative), -5);
+  });
+
+  test("a ByteString is base64, not a list of byte values", () => {
+    assert.equal(variantToJson(NATIVE.bytestring), "YWJj");
+  });
+
+  test("a Byte array stays an array of numbers", () => {
+    assert.deepEqual(variantToJson(NATIVE.byte_array), [97, 98, 99]);
+  });
+});
+
+// The canonical record shape (contract -> resultShapes.historyRecords).
 describe("history records", () => {
   /** A minimal DataValue stand-in — the fields toHistoryRecord actually reads. */
-  const dataValue = (value, { timestamp = new Date("2026-09-09T13:36:01.139Z"), status } = {}) => ({
-    value: value === undefined ? undefined : { value },
+  const dataValue = (
+    variant,
+    { timestamp = new Date("2026-09-09T13:36:01.139Z"), status } = {}
+  ) => ({
+    value: variant,
     sourceTimestamp: timestamp,
     statusCode: status === undefined ? undefined : { name: status },
   });
 
   test("flattens a DataValue to {value, timestamp, status}", () => {
-    assert.deepEqual(toHistoryRecords([dataValue(51.75, { status: "Good" })]), [
+    assert.deepEqual(toHistoryRecords([dataValue(NATIVE.double, { status: "Good" })]), [
       { value: 51.75, timestamp: "2026-09-09T13:36:01.139Z", status: "Good" },
     ]);
-  });
-
-  test("keeps the value JSON-native rather than stringifying it", () => {
-    assert.equal(toJsonValue(51.75), 51.75);
-    assert.equal(toJsonValue(true), true);
-    assert.equal(toJsonValue("AUTO"), "AUTO");
-    assert.deepEqual(toJsonValue(new Float64Array([1, 2])), [1, 2]);
   });
 
   test("an empty aggregate interval is null, not a stringified placeholder", () => {
@@ -107,13 +197,7 @@ describe("history records", () => {
   });
 
   test("an absent status code means Good", () => {
-    assert.equal(toHistoryRecords([dataValue(1)])[0].status, "Good");
-  });
-
-  test("stringifies values JSON cannot carry", () => {
-    assert.equal(toJsonValue(NaN), "NaN");
-    assert.equal(toJsonValue(Infinity), "Infinity");
-    assert.equal(toJsonValue({ toString: () => "ns=2;i=3" }), "ns=2;i=3");
+    assert.equal(toHistoryRecords([dataValue(NATIVE.int32)])[0].status, "Good");
   });
 
   test("timestamps are ISO-8601 UTC with a trailing Z", () => {

--- a/packages/server-node/test/unit.test.mjs
+++ b/packages/server-node/test/unit.test.mjs
@@ -10,6 +10,7 @@ import test, { describe } from "node:test";
 import { fileURLToPath } from "node:url";
 
 import { toDate } from "../build/dates.js";
+import { toHistoryRecords, toIsoUtc, toJsonValue } from "../build/records.js";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -72,6 +73,58 @@ describe("toDate", () => {
     // 2026-03-01T01:00+02:00 is 2026-02-28T23:00Z — the UTC day differs from the
     // string's day, which must not be mistaken for an impossible date.
     assert.equal(toDate("2026-03-01T01:00:00+02:00").toISOString(), "2026-02-28T23:00:00.000Z");
+  });
+});
+
+// The canonical history-family record shape (contract -> resultShapes.historyRecords).
+// The Python server's equivalent tests are in tests/unit/test_records.py; both
+// assert the same shape, because a client must be able to read either server.
+describe("history records", () => {
+  /** A minimal DataValue stand-in — the fields toHistoryRecord actually reads. */
+  const dataValue = (value, { timestamp = new Date("2026-09-09T13:36:01.139Z"), status } = {}) => ({
+    value: value === undefined ? undefined : { value },
+    sourceTimestamp: timestamp,
+    statusCode: status === undefined ? undefined : { name: status },
+  });
+
+  test("flattens a DataValue to {value, timestamp, status}", () => {
+    assert.deepEqual(toHistoryRecords([dataValue(51.75, { status: "Good" })]), [
+      { value: 51.75, timestamp: "2026-09-09T13:36:01.139Z", status: "Good" },
+    ]);
+  });
+
+  test("keeps the value JSON-native rather than stringifying it", () => {
+    assert.equal(toJsonValue(51.75), 51.75);
+    assert.equal(toJsonValue(true), true);
+    assert.equal(toJsonValue("AUTO"), "AUTO");
+    assert.deepEqual(toJsonValue(new Float64Array([1, 2])), [1, 2]);
+  });
+
+  test("an empty aggregate interval is null, not a stringified placeholder", () => {
+    const [record] = toHistoryRecords([dataValue(undefined, { status: "BadNoData" })]);
+    assert.equal(record.value, null);
+    assert.equal(record.status, "BadNoData");
+  });
+
+  test("an absent status code means Good", () => {
+    assert.equal(toHistoryRecords([dataValue(1)])[0].status, "Good");
+  });
+
+  test("stringifies values JSON cannot carry", () => {
+    assert.equal(toJsonValue(NaN), "NaN");
+    assert.equal(toJsonValue(Infinity), "Infinity");
+    assert.equal(toJsonValue({ toString: () => "ns=2;i=3" }), "ns=2;i=3");
+  });
+
+  test("timestamps are ISO-8601 UTC with a trailing Z", () => {
+    assert.equal(toIsoUtc(new Date("2026-09-09T15:36:01.468+02:00")), "2026-09-09T13:36:01.468Z");
+    assert.equal(toIsoUtc(undefined), null);
+    assert.equal(toIsoUtc(new Date("nope")), null);
+  });
+
+  test("no data values is an empty record list", () => {
+    assert.deepEqual(toHistoryRecords(undefined), []);
+    assert.deepEqual(toHistoryRecords([]), []);
   });
 });
 

--- a/packages/server-python/src/opcua_mcp_server/__init__.py
+++ b/packages/server-python/src/opcua_mcp_server/__init__.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from .config import SERVER_URL
 from .contract import CONTRACT, DESC, HISTORY_NODE_ID, load_contract
 from .datetimes import format_iso_utc, parse_iso_datetime
-from .records import history_record, history_records, json_value
+from .records import history_record, history_records, scalar_to_json, variant_to_json
 from .server import main, mcp
 
 __all__ = [
@@ -24,9 +24,10 @@ __all__ = [
     "format_iso_utc",
     "history_record",
     "history_records",
-    "json_value",
     "load_contract",
     "main",
     "mcp",
     "parse_iso_datetime",
+    "scalar_to_json",
+    "variant_to_json",
 ]

--- a/packages/server-python/src/opcua_mcp_server/__init__.py
+++ b/packages/server-python/src/opcua_mcp_server/__init__.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 
 from .config import SERVER_URL
 from .contract import CONTRACT, DESC, HISTORY_NODE_ID, load_contract
-from .datetimes import parse_iso_datetime
+from .datetimes import format_iso_utc, parse_iso_datetime
+from .records import history_record, history_records, json_value
 from .server import main, mcp
 
 __all__ = [
@@ -20,6 +21,10 @@ __all__ = [
     "DESC",
     "HISTORY_NODE_ID",
     "SERVER_URL",
+    "format_iso_utc",
+    "history_record",
+    "history_records",
+    "json_value",
     "load_contract",
     "main",
     "mcp",

--- a/packages/server-python/src/opcua_mcp_server/datetimes.py
+++ b/packages/server-python/src/opcua_mcp_server/datetimes.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 def parse_iso_datetime(value: str | None) -> datetime | None:
@@ -20,3 +20,22 @@ def parse_iso_datetime(value: str | None) -> datetime | None:
         raise ValueError(
             f'Invalid date/time: "{value}". Use ISO 8601, e.g. 2026-04-23T17:40:00Z'
         ) from None
+
+
+def format_iso_utc(value: datetime | None) -> str | None:
+    """Render a datetime as ISO-8601 UTC with a trailing ``Z``.
+
+    The inverse of :func:`parse_iso_datetime`, and the format the history-family
+    tools return (``contract/tools.json`` -> ``resultShapes.historyRecords``).
+    Previously these timestamps were ``str(datetime)`` — ``"2026-09-09 13:36:01.468000"``,
+    space-separated and with no zone — which is not what the same tools *accept*
+    for ``start_time``/``end_time``, and not what the Node server emitted.
+
+    python-opcua decodes OPC UA DateTimes into naive datetimes that are already
+    UTC, so a naive value is labelled UTC rather than reinterpreted as local time.
+    """
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/packages/server-python/src/opcua_mcp_server/records.py
+++ b/packages/server-python/src/opcua_mcp_server/records.py
@@ -1,0 +1,56 @@
+"""The canonical record shape for the history family of tools.
+
+``contract/tools.json`` -> ``resultShapes.historyRecords`` is the specification;
+this module is the Python implementation of it, and ``src/records.ts`` in the
+Node server is the other. Both servers must emit comparable records: a client —
+or a model — that has learned one server's output has to be able to read the
+other's. The two used to diverge (this server returned flat stringified records,
+the Node server raw ``DataValue`` JSON); see issue #23.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from math import isfinite
+from typing import Any
+
+from .datetimes import format_iso_utc
+
+#: An absent StatusCode means Good in OPC UA, so name it rather than return None.
+_DEFAULT_STATUS = "Good"
+
+
+def json_value(value: Any) -> Any:
+    """An OPC UA value as JSON, without the Variant wrapper.
+
+    Values that JSON can carry (number, boolean, string, and sequences of those)
+    pass through as themselves, so a consumer gets ``51.75`` rather than
+    ``"51.75"`` — and an empty aggregate interval gets ``null`` rather than the
+    string ``"None"``. Anything else — a datetime, a NodeId, an ExtensionObject —
+    becomes its string form, which is lossy but always serialisable.
+    """
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        # NaN and ±inf are not JSON. json.dumps emits bare `NaN`, which is not
+        # parseable by a strict client, so send the string form instead.
+        return value if isfinite(value) else str(value)
+    if isinstance(value, (list, tuple)):
+        return [json_value(item) for item in value]
+    return str(value)
+
+
+def history_record(data_value: Any) -> dict:
+    """One opcua ``DataValue`` as a canonical record."""
+    variant = getattr(data_value, "Value", None)
+    status = getattr(data_value, "StatusCode", None)
+    return {
+        "value": json_value(getattr(variant, "Value", None)),
+        "timestamp": format_iso_utc(getattr(data_value, "SourceTimestamp", None)),
+        "status": str(status.name) if status is not None else _DEFAULT_STATUS,
+    }
+
+
+def history_records(data_values: Iterable[Any] | None) -> list[dict]:
+    """A history/aggregate result as canonical records."""
+    return [history_record(data_value) for data_value in data_values or ()]

--- a/packages/server-python/src/opcua_mcp_server/records.py
+++ b/packages/server-python/src/opcua_mcp_server/records.py
@@ -2,15 +2,25 @@
 
 ``contract/tools.json`` -> ``resultShapes.historyRecords`` is the specification;
 this module is the Python implementation of it, and ``src/records.ts`` in the
-Node server is the other. Both servers must emit comparable records: a client —
-or a model — that has learned one server's output has to be able to read the
-other's. The two used to diverge (this server returned flat stringified records,
-the Node server raw ``DataValue`` JSON); see issue #23.
+Node server is the other. Both servers must emit the same record for the same
+reading: a client — or a model — that has learned one server's output has to be
+able to read the other's. See issue #23.
+
+Conversion keys on the OPC UA *data type*, not on the Python runtime type. That
+is not incidental. The two client libraries represent the same OPC UA value with
+wildly different native types — a ByteString is ``bytes`` here and a ``Buffer``
+in Node, an Int64 is a plain ``int`` here and a ``[high, low]`` pair in Node — so
+anything reaching for ``str(value)`` as its primary signal diverges by
+construction. The per-type table is shared, and pinned from both sides by
+``tests/fixtures/value-encoding.json``.
 """
 
 from __future__ import annotations
 
+import uuid
+from base64 import b64encode
 from collections.abc import Iterable
+from datetime import datetime
 from math import isfinite
 from typing import Any
 
@@ -19,33 +29,127 @@ from .datetimes import format_iso_utc
 #: An absent StatusCode means Good in OPC UA, so name it rather than return None.
 _DEFAULT_STATUS = "Good"
 
+#: Past this, a JSON number silently loses digits in any JavaScript parser.
+_MAX_SAFE_INTEGER = 2**53 - 1
 
-def json_value(value: Any) -> Any:
-    """An OPC UA value as JSON, without the Variant wrapper.
 
-    Values that JSON can carry (number, boolean, string, and sequences of those)
-    pass through as themselves, so a consumer gets ``51.75`` rather than
-    ``"51.75"`` — and an empty aggregate interval gets ``null`` rather than the
-    string ``"None"``. Anything else — a datetime, a NodeId, an ExtensionObject —
-    becomes its string form, which is lossy but always serialisable.
+def _int_to_json(value: int) -> int | str:
+    """A 64-bit integer as a JSON number, or a decimal string when it cannot be one.
+
+    Python integers are arbitrary precision, so an Int64 counter round-trips
+    here but would be rounded by the receiving JavaScript. Both servers switch to
+    a string at the same threshold, so neither rounds behind the caller's back.
     """
-    if value is None or isinstance(value, (bool, int, str)):
+    return value if -_MAX_SAFE_INTEGER <= value <= _MAX_SAFE_INTEGER else str(value)
+
+
+def _float_to_json(value: float) -> float | str:
+    """A float as JSON, with the non-finite values spelled as OPC UA spells them.
+
+    JSON has no NaN or infinity: ``json.dumps`` emits a bare ``NaN``, which
+    strict parsers reject. The string form has to be the *same* string on both
+    servers, and Python's ``str(float("nan"))`` is ``"nan"`` where JavaScript's
+    is ``"NaN"`` — so the spelling from OPC UA Part 6's JSON encoding is used
+    explicitly rather than left to either language's formatter.
+    """
+    if isfinite(value):
+        return value
+    if value != value:  # NaN is the only value not equal to itself.
+        return "NaN"
+    return "Infinity" if value > 0 else "-Infinity"
+
+
+def _bytes_to_json(value: bytes | bytearray | memoryview) -> str:
+    """A ByteString as base64, the encoding OPC UA Part 6 gives it in JSON."""
+    return b64encode(bytes(value)).decode("ascii")
+
+
+def scalar_to_json(value: Any, type_name: str = "") -> Any:
+    """One scalar OPC UA value as JSON, given its variant type name."""
+    if value is None:
+        return None
+
+    # Types whose native representation differs between the two client libraries.
+    if type_name in ("Int64", "UInt64"):
+        return _int_to_json(int(value))
+    if type_name == "ByteString":
+        if isinstance(value, (bytes, bytearray, memoryview)):
+            return _bytes_to_json(value)
+        return str(value)
+    if type_name == "DateTime":
+        return format_iso_utc(value) if isinstance(value, datetime) else str(value)
+    if type_name == "Guid":
+        # Lower case: the RFC 4122 canonical form. node-opcua renders GUIDs upper.
+        return str(value).lower()
+    if type_name == "StatusCode":
+        return str(getattr(value, "name", value))
+    if type_name == "LocalizedText":
+        # The text only; the locale is not part of the reading.
+        return getattr(value, "Text", None) or ""
+    if type_name in ("NodeId", "ExpandedNodeId"):
+        # `str(NodeId)` is a Python repr — "NumericNodeId(ns=2;i=3)". The Node
+        # server emits the canonical "ns=2;i=3", so use the method that gives it.
+        return value.to_string() if hasattr(value, "to_string") else str(value)
+    if type_name == "QualifiedName":
+        return f"{value.NamespaceIndex}:{value.Name}"
+
+    # `bool` first: it is a subclass of `int` in Python, and must stay a boolean.
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return _int_to_json(value)
+    if isinstance(value, str):
         return value
     if isinstance(value, float):
-        # NaN and ±inf are not JSON. json.dumps emits bare `NaN`, which is not
-        # parseable by a strict client, so send the string form instead.
-        return value if isfinite(value) else str(value)
+        return _float_to_json(value)
+
+    # Fallbacks for a value that arrived without a usable variant type.
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return _bytes_to_json(value)
+    if isinstance(value, datetime):
+        return format_iso_utc(value)
+    if isinstance(value, uuid.UUID):
+        return str(value)
     if isinstance(value, (list, tuple)):
-        return [json_value(item) for item in value]
+        return [scalar_to_json(item, type_name) for item in value]
+
+    # Structured and opaque types (ExtensionObject, XmlElement, …) degrade to a
+    # string. Those are not the shape of anything a server historises as a
+    # variable value, and a faithful cross-runtime encoding of them would be a
+    # much larger undertaking than this record is worth.
     return str(value)
+
+
+def variant_to_json(variant: Any) -> Any:
+    """An OPC UA value as JSON, without the Variant wrapper.
+
+    Values that JSON can carry pass through as themselves, so a consumer gets
+    ``51.75`` rather than ``"51.75"`` — and an empty aggregate interval gets
+    ``null`` rather than the string ``"None"``. Everything else follows the
+    per-type table in :func:`scalar_to_json`.
+    """
+    if variant is None:
+        return None
+
+    value = getattr(variant, "Value", None)
+    if value is None:
+        return None
+
+    type_name = getattr(getattr(variant, "VariantType", None), "name", "")
+
+    # Array-ness comes from the variant where it says so. Unlike Node, duck-typing
+    # is a safe fallback here: no scalar python-opcua value is a list.
+    if getattr(variant, "is_array", False) or isinstance(value, (list, tuple)):
+        return [scalar_to_json(item, type_name) for item in value]
+
+    return scalar_to_json(value, type_name)
 
 
 def history_record(data_value: Any) -> dict:
     """One opcua ``DataValue`` as a canonical record."""
-    variant = getattr(data_value, "Value", None)
     status = getattr(data_value, "StatusCode", None)
     return {
-        "value": json_value(getattr(variant, "Value", None)),
+        "value": variant_to_json(getattr(data_value, "Value", None)),
         "timestamp": format_iso_utc(getattr(data_value, "SourceTimestamp", None)),
         "status": str(status.name) if status is not None else _DEFAULT_STATUS,
     }

--- a/packages/server-python/src/opcua_mcp_server/server.py
+++ b/packages/server-python/src/opcua_mcp_server/server.py
@@ -19,6 +19,7 @@ from .capabilities import server_aggregate_functions, server_supports_history
 from .config import SERVER_URL
 from .contract import DESC
 from .datetimes import parse_iso_datetime
+from .records import history_records
 
 
 # Manage the lifecycle of the OPC UA client connection
@@ -101,8 +102,10 @@ def read_history_opcua_node(
         num_values (int): Number of values to read (default: unlimited)
 
     Returns:
-        list[dict]: An array of values shaped
-            `{ "value": <value>, "timestamp": <timestamp>, "status": "Good" }`
+        list[dict]: One record per historical value, shaped
+            `{ "value": <value>, "timestamp": "<ISO-8601 UTC>", "status": "Good" }`
+            — the shared shape defined in `contract/tools.json`
+            (`resultShapes.historyRecords`) and matched by the Node server.
     """
     client = ctx.request_context.lifespan_context["opcua_client"]
     node = client.get_node(node_id)
@@ -111,14 +114,7 @@ def read_history_opcua_node(
         endtime=parse_iso_datetime(end_time),
         numvalues=num_values,
     )
-    return [
-        {
-            "value": str(v.Value.Value),
-            "timestamp": str(v.SourceTimestamp),
-            "status": str(v.StatusCode.name),
-        }
-        for v in values
-    ]
+    return history_records(values)
 
 
 # Conditionally register the history tool based on server capability.
@@ -155,8 +151,12 @@ def read_aggregate_opcua_node(
                                      the server for a single value over the range.
 
     Returns:
-        list[dict]: One entry per interval, shaped
-            `{ "value": <value>, "timestamp": <timestamp>, "status": <status> }`
+        list[dict]: One record per interval, shaped
+            `{ "value": <value>, "timestamp": "<ISO-8601 UTC>", "status": "Good" }`
+            — the shared shape defined in `contract/tools.json`
+            (`resultShapes.historyRecords`) and matched by the Node server. An
+            interval the server holds no data for has a null `value` and a
+            non-Good `status`.
     """
     # Re-probe rather than trusting the import-time snapshot: a server may gain or
     # lose aggregate support while this process is running, and answering from a
@@ -179,14 +179,7 @@ def read_aggregate_opcua_node(
         if not result.StatusCode.is_good():
             raise ValueError(f"Read aggregate failed with status: {result.StatusCode}")
 
-        return [
-            {
-                "value": str(v.Value.Value),
-                "timestamp": str(v.SourceTimestamp),
-                "status": str(v.StatusCode.name),
-            }
-            for v in result.HistoryData.DataValues
-        ]
+        return history_records(result.HistoryData.DataValues)
     except Exception as e:
         raise ValueError(f"Failed to read node {node_id}: {e!s}") from e
 

--- a/tests/e2e/test_aggregate_e2e.py
+++ b/tests/e2e/test_aggregate_e2e.py
@@ -16,13 +16,21 @@ Run:
 
 from __future__ import annotations
 
-import json
 from datetime import datetime, timedelta, timezone
 from itertools import pairwise
 
 import pytest
 from conftest import AGGREGATE_NODE_ID, AGGREGATE_RAMP_PER_SECOND
-from test_mcp_e2e import NODE_BUILD, _server_params, connect, text_of, tool_names
+from test_contract_parity import assert_matches_result_shape
+from test_mcp_e2e import (
+    ISO_UTC_TIMESTAMP,
+    NODE_BUILD,
+    _server_params,
+    connect,
+    records_of,
+    text_of,
+    tool_names,
+)
 
 AGGREGATE_TOOL = "read_aggregate_opcua_node"
 
@@ -52,31 +60,18 @@ def iso_utc(offset_seconds: int = 0) -> str:
     return moment.isoformat().replace("+00:00", "Z")
 
 
-def aggregate_values(result, impl: str) -> list[float | None]:
-    """Extract the per-bucket values from an aggregate result.
+def aggregate_values(result) -> list[float | None]:
+    """The per-bucket values of an aggregate result, ``None`` for an empty bucket.
 
-    The two servers return different shapes for the history family (see #23), so
-    this normalises both to a list of floats with ``None`` for empty buckets.
+    Both servers emit the contract's ``historyRecords`` shape, so this needs no
+    per-implementation branch — it used to, because the Node server returned raw
+    node-opcua ``DataValue`` JSON and stringified nothing while the Python server
+    reported an empty bucket as the string ``"None"`` (issue #23).
     """
-    if impl == "python":
-        values: list[float | None] = []
-        for block in result.content:
-            text = getattr(block, "text", None)
-            if not text or not text.strip().startswith("{"):
-                continue
-            raw = json.loads(text).get("value")
-            values.append(None if raw in (None, "None") else float(raw))
-        return values
-
-    # Node returns a single JSON array of DataValues; empty buckets carry no value.
-    values = []
-    for data_value in json.loads(text_of(result)):
-        raw = (data_value.get("value") or {}).get("value")
-        values.append(None if raw is None else float(raw))
-    return values
+    return [record["value"] for record in records_of(result)]
 
 
-async def read_average(session, impl, *, window_seconds, interval_ms, end_time="explicit"):
+async def read_average(session, *, window_seconds, interval_ms, end_time="explicit"):
     """Read Average over the last ``window_seconds``, bucketed by ``interval_ms``."""
     arguments = {
         "node_id": AGGREGATE_NODE_ID,
@@ -87,7 +82,7 @@ async def read_average(session, impl, *, window_seconds, interval_ms, end_time="
     if end_time == "explicit":
         arguments["end_time"] = iso_utc()
     result = await session.call_tool(AGGREGATE_TOOL, arguments)
-    return result, aggregate_values(result, impl)
+    return result, aggregate_values(result)
 
 
 # --- tests ---------------------------------------------------------------------
@@ -111,11 +106,17 @@ async def test_aggregate_average_values_are_correct(agg_server):
     impl, params = agg_server
     interval_ms = 5000
     async with connect(params) as session:
-        result, values = await read_average(
-            session, impl, window_seconds=20, interval_ms=interval_ms
-        )
+        result, values = await read_average(session, window_seconds=20, interval_ms=interval_ms)
 
     assert not result.isError, text_of(result)
+    records = records_of(result)
+    # The aggregate tool shares the history tool's record shape (contract ->
+    # resultShapes.historyRecords); both servers must produce it.
+    assert_matches_result_shape(records, "historyRecords", f"{impl}/{AGGREGATE_TOOL}")
+    assert all(ISO_UTC_TIMESTAMP.match(r["timestamp"]) for r in records), (
+        f"{impl}: bucket timestamps are not ISO-8601 UTC: {[r['timestamp'] for r in records]}"
+    )
+
     populated = [v for v in values if v is not None]
     assert len(populated) >= 3, f"{impl}: too few populated buckets: {values}"
 
@@ -147,7 +148,6 @@ async def test_aggregate_default_end_time_is_utc(agg_server):
     async with connect(skewed) as session:
         result, values = await read_average(
             session,
-            impl,
             window_seconds=window_seconds,
             interval_ms=interval_ms,
             end_time="default",

--- a/tests/e2e/test_contract_parity.py
+++ b/tests/e2e/test_contract_parity.py
@@ -3,8 +3,9 @@
 The Node server builds its tools/list directly from the contract; the Python
 server sources its tool descriptions and capability node IDs from it. This test
 asserts that, against the mock server, BOTH servers advertise exactly the
-contract's applicable tools, with matching descriptions and parameter sets — so
-the two implementations cannot silently drift.
+contract's applicable tools, with matching descriptions and parameter sets, and
+that what they actually return matches the contract's declared ``resultShape`` —
+so the two implementations cannot silently drift.
 
 Run as part of the normal suite:
     uv sync --all-packages && cd tests && uv run --no-sync pytest -v
@@ -16,7 +17,7 @@ import json
 
 import pytest
 from conftest import ROOT
-from test_mcp_e2e import NODE_BUILD, _server_params, connect
+from test_mcp_e2e import NODE, NODE_BUILD, _server_params, connect, records_of, text_of
 
 CONTRACT = json.loads((ROOT / "contract" / "tools.json").read_text())
 
@@ -24,6 +25,59 @@ CONTRACT = json.loads((ROOT / "contract" / "tools.json").read_text())
 # so the contract tools applicable here are those with no capability + history.
 _MOCK_CAPS = {None, "history"}
 EXPECTED = {t["name"]: t for t in CONTRACT["tools"] if t["capability"] in _MOCK_CAPS}
+
+RESULT_SHAPES = CONTRACT["resultShapes"]
+
+# Minimal JSON-Schema evaluation: the contract's record schemas use only these
+# keywords, and a `jsonschema` dependency for a handful of asserts would be more
+# machinery than the check is worth.
+_JSON_TYPES = {
+    "string": str,
+    "number": (int, float),
+    "boolean": bool,
+    "object": dict,
+    "array": list,
+    "null": type(None),
+}
+
+
+def _matches_type(value, declared) -> bool:
+    """True when ``value`` satisfies a schema ``type`` (a name, a list, or absent)."""
+    if declared is None:
+        return True  # No declared type — any JSON value is allowed.
+    names = [declared] if isinstance(declared, str) else declared
+    # `bool` is a subclass of `int`, so a boolean must not pass as a number.
+    if isinstance(value, bool) and "boolean" not in names:
+        return False
+    return any(isinstance(value, _JSON_TYPES[name]) for name in names)
+
+
+def assert_matches_result_shape(records: list[dict], shape_name: str, context: str) -> None:
+    """Assert every record satisfies the named shape from ``contract/tools.json``.
+
+    This is what makes the shape enforceable rather than merely documented: the
+    contract file is the assertion, so changing either server's output without
+    changing the contract fails here.
+    """
+    record_schema = RESULT_SHAPES[shape_name]["items"]
+    properties = record_schema["properties"]
+    required = set(record_schema["required"])
+
+    for record in records:
+        assert isinstance(record, dict), f"{context}: record is not an object: {record!r}"
+        assert set(record) >= required, (
+            f"{context}: record is missing {sorted(required - set(record))}: {record!r}"
+        )
+        if record_schema.get("additionalProperties") is False:
+            assert set(record) <= set(properties), (
+                f"{context}: record has fields outside the contract "
+                f"{sorted(set(record) - set(properties))}: {record!r}"
+            )
+        for field, spec in properties.items():
+            assert _matches_type(record[field], spec.get("type")), (
+                f"{context}: {field}={record[field]!r} does not match "
+                f"declared type {spec.get('type')!r}"
+            )
 
 
 def _props_required(schema: dict) -> tuple[set, set]:
@@ -66,3 +120,26 @@ async def test_servers_match_contract(impl_params):
             f"{impl}/{name}: params {got_props} != contract {want_props}"
         )
         assert got_req == want_req, f"{impl}/{name}: required {got_req} != contract {want_req}"
+
+
+async def test_history_result_matches_the_contract_shape(impl_params):
+    """Both servers' history output must match the contract's declared shape.
+
+    Tool *names* were unified from the start, but the response shape was not: the
+    Node server returned raw node-opcua ``DataValue`` JSON while the Python
+    server returned flat records, so a client that learned one misread the other
+    (issue #23). The contract now declares the shape and this asserts it.
+    """
+    impl, params = impl_params
+    spec = EXPECTED["read_history_opcua_node"]
+    assert spec["resultShape"] == "historyRecords"
+
+    async with connect(params) as session:
+        result = await session.call_tool(
+            "read_history_opcua_node", {"node_id": NODE["Temperature"], "num_values": 3}
+        )
+
+    assert not result.isError, text_of(result)
+    records = records_of(result)
+    assert records, f"{impl}: no history records to check the shape against"
+    assert_matches_result_shape(records, spec["resultShape"], f"{impl}/read_history_opcua_node")

--- a/tests/e2e/test_mcp_e2e.py
+++ b/tests/e2e/test_mcp_e2e.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 from contextlib import asynccontextmanager
 
 import pytest
@@ -59,6 +60,11 @@ HISTORY_TOOL = {
 }
 
 NODE_BUILD = ROOT / "packages" / "server-node" / "build" / "index.js"
+
+# ISO-8601 UTC, as `resultShapes.historyRecords` requires: a trailing `Z`, and no
+# space-separated `str(datetime)` form. Sub-second digits vary by runtime
+# (microseconds from Python, milliseconds from Node), which the contract allows.
+ISO_UTC_TIMESTAMP = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$")
 
 
 def _server_params(impl: str, url: str) -> StdioServerParameters:
@@ -109,6 +115,27 @@ def text_of(result) -> str:
         if text is not None:
             parts.append(text)
     return "\n".join(parts)
+
+
+def records_of(result) -> list[dict]:
+    """Parse a history-family response into its records.
+
+    Both servers emit one JSON object per content block, shaped by the contract's
+    ``resultShapes.historyRecords``, so this needs no per-implementation branch.
+    It used to: the Node server returned a single array of raw node-opcua
+    ``DataValue``s (``{"statusCode": {"value": 1}, "sourceTimestamp": …}``) while
+    the Python server returned flat records, and a caller had to know which
+    server it was talking to (issue #23).
+    """
+    records = []
+    for block in result.content:
+        text = getattr(block, "text", None)
+        assert text is not None, f"non-text block in a history response: {block!r}"
+        try:
+            records.append(json.loads(text))
+        except json.JSONDecodeError as exc:  # pragma: no cover - failure path
+            raise AssertionError(f"history block is not JSON: {text!r}") from exc
+    return records
 
 
 async def tool_names(session) -> set[str]:
@@ -292,17 +319,40 @@ async def test_call_method_start_then_stop(server):
 
 
 async def test_read_history(server):
-    """Read recent history for the Temperature sensor and assert we get records."""
+    """Read recent history for the Temperature sensor and assert the canonical shape.
+
+    Both servers must return the same records, field for field — see
+    ``contract/tools.json`` -> ``resultShapes.historyRecords``. The schema-driven
+    version of this check is in ``test_contract_parity.py``; what is asserted
+    here is that real history reads through it correctly on both runtimes.
+    """
     impl, params = server
     async with connect(params) as session:
         result = await session.call_tool(
             HISTORY_TOOL[impl], {"node_id": NODE["Temperature"], "num_values": 5}
         )
     assert not result.isError, text_of(result)
-    text = text_of(result)
-    # Both implementations surface a Good status and a timestamp per record.
-    assert "Good" in text or "sourceTimestamp" in text or "timestamp" in text
-    assert text.strip() not in ("", "[]")
+
+    records = records_of(result)
+    assert records, f"{impl}: no history records returned"
+    assert len(records) <= 5, f"{impl}: num_values=5 returned {len(records)} records"
+    for record in records:
+        assert set(record) == {"value", "timestamp", "status"}, (
+            f"{impl}: record fields {sorted(record)} are not the contract's"
+        )
+        assert record["status"] == "Good", f"{impl}: unexpected status: {record}"
+        # Temperature is a Double. `bool` is excluded because it is an `int` in
+        # Python, and JSON has no integer/float distinction — a whole number
+        # arrives as `int` from the Node server and `float` from the Python one.
+        assert isinstance(record["value"], (int, float)) and not isinstance(
+            record["value"], bool
+        ), f"{impl}: value is not a number: {record!r}"
+        assert ISO_UTC_TIMESTAMP.match(record["timestamp"]), (
+            f"{impl}: timestamp is not ISO-8601 UTC: {record['timestamp']!r}"
+        )
+
+    # Not asserted: ordering. Given `num_values` alone, an OPC UA server reads
+    # backwards from now, and both servers pass that ordering through unchanged.
 
 
 # --- browse parsing (server output formats differ) -----------------------------

--- a/tests/fixtures/value-encoding.json
+++ b/tests/fixtures/value-encoding.json
@@ -1,0 +1,133 @@
+{
+  "$comment": "The canonical JSON encoding of an OPC UA value, per data type — the `value` field of contract/tools.json -> resultShapes.historyRecords. Both servers must produce `expected` for the same reading, so this file is the shared expectation: tests/unit/test_records.py and packages/server-node/test/unit.test.mjs each build the native value for every case name below and assert the result matches. Neither suite may skip a case, so adding one here forces both runtimes to handle it. Encodings follow OPC UA Part 6's JSON encoding where it defines one (base64 for ByteString, ISO-8601 for DateTime, a JSON string for 64-bit integers that cannot survive as a JSON number).",
+  "cases": [
+    {
+      "name": "boolean",
+      "type": "Boolean",
+      "expected": true,
+      "note": "Booleans stay booleans; they must never arrive as 1/0 or \"True\"."
+    },
+    {
+      "name": "int32",
+      "type": "Int32",
+      "expected": 42
+    },
+    {
+      "name": "int64_small",
+      "type": "Int64",
+      "expected": 5,
+      "note": "node-opcua carries Int64 as a [high, low] pair of 32-bit halves; python-opcua as a plain int. Both must land on the same JSON number."
+    },
+    {
+      "name": "int64_negative",
+      "type": "Int64",
+      "expected": -5,
+      "note": "The [high, low] pair is two's complement: -5 is [4294967295, 4294967291]."
+    },
+    {
+      "name": "int64_beyond_double",
+      "type": "Int64",
+      "expected": "9007199254740993",
+      "note": "2^53+1. A JSON *number* loses digits here in any JS parser, so both servers switch to a decimal string at the same threshold rather than one of them silently rounding."
+    },
+    {
+      "name": "uint64_max",
+      "type": "UInt64",
+      "expected": "18446744073709551615"
+    },
+    {
+      "name": "double",
+      "type": "Double",
+      "expected": 51.75
+    },
+    {
+      "name": "double_nan",
+      "type": "Double",
+      "expected": "NaN",
+      "note": "JSON has no NaN. Emitting a bare NaN produces output that strict parsers reject, so it becomes a string."
+    },
+    {
+      "name": "double_infinity",
+      "type": "Double",
+      "expected": "Infinity"
+    },
+    {
+      "name": "string",
+      "type": "String",
+      "expected": "AUTO"
+    },
+    {
+      "name": "datetime",
+      "type": "DateTime",
+      "expectedPattern": "^2026-09-09T13:36:01\\.468(000)?Z$",
+      "note": "A pattern, not a literal: node-opcua's Date holds milliseconds while python-opcua decodes the full microsecond resolution, and truncating Python would discard real data to match a JS limitation. This is the one permitted difference, and it is the same one the `timestamp` field carries."
+    },
+    {
+      "name": "guid",
+      "type": "Guid",
+      "expected": "72962b91-fa75-4ae6-8d28-b404dc7daf63",
+      "note": "Lower-case, the RFC 4122 canonical form. node-opcua renders GUIDs upper-case."
+    },
+    {
+      "name": "bytestring",
+      "type": "ByteString",
+      "expected": "YWJj",
+      "note": "base64 of b\"abc\". python-opcua supplies bytes and node-opcua a Buffer; without an explicit rule these became \"b'abc'\" and [97, 98, 99] respectively."
+    },
+    {
+      "name": "nodeid",
+      "type": "NodeId",
+      "expected": "ns=2;i=3"
+    },
+    {
+      "name": "statuscode",
+      "type": "StatusCode",
+      "expected": "Good",
+      "note": "The name alone, matching the record's own `status` field."
+    },
+    {
+      "name": "qualifiedname",
+      "type": "QualifiedName",
+      "expected": "2:Temperature"
+    },
+    {
+      "name": "localizedtext",
+      "type": "LocalizedText",
+      "expected": "Ambient temperature",
+      "note": "The text only. The locale is dropped: it is not part of the reading."
+    },
+    {
+      "name": "double_array",
+      "type": "Double",
+      "expected": [1.5, 2.5]
+    },
+    {
+      "name": "byte_array",
+      "type": "Byte",
+      "expected": [97, 98, 99],
+      "note": "An array of Byte is an array of numbers — unlike a ByteString, which is one opaque blob."
+    },
+    {
+      "name": "int64_array",
+      "type": "Int64",
+      "expected": [5, "9007199254740993"],
+      "note": "Element-wise, so one oversized element does not stringify the rest."
+    },
+    {
+      "name": "bytestring_array",
+      "type": "ByteString",
+      "expected": ["YWI=", "Yw=="]
+    },
+    {
+      "name": "empty_array",
+      "type": "Double",
+      "expected": []
+    },
+    {
+      "name": "null",
+      "type": "Null",
+      "expected": null,
+      "note": "No value at all — an aggregate interval the server holds no data for."
+    }
+  ]
+}

--- a/tests/unit/test_contract.py
+++ b/tests/unit/test_contract.py
@@ -16,7 +16,9 @@ from conftest import ROOT
 CONTRACT = json.loads((ROOT / "contract" / "tools.json").read_text())
 TOOLS = CONTRACT["tools"]
 CAPABILITIES = CONTRACT["capabilities"]
+RESULT_SHAPES = {k: v for k, v in CONTRACT["resultShapes"].items() if not k.startswith("$")}
 TOOL_IDS = [t["name"] for t in TOOLS]
+SHAPE_IDS = sorted(RESULT_SHAPES)
 
 
 def test_tool_names_are_unique():
@@ -69,3 +71,49 @@ def test_python_server_sources_every_description_from_the_contract():
     assert set(DESC) == set(TOOL_IDS)
     for tool in TOOLS:
         assert DESC[tool["name"]] == tool["description"]
+
+
+@pytest.mark.parametrize("tool", TOOLS, ids=TOOL_IDS)
+def test_result_shape_is_declared(tool):
+    """A tool may only name a result shape the contract actually defines."""
+    shape = tool.get("resultShape")
+    assert shape is None or shape in RESULT_SHAPES, (
+        f"{tool['name']} declares unknown resultShape {shape!r}; known: {SHAPE_IDS}"
+    )
+
+
+@pytest.mark.parametrize("name", SHAPE_IDS, ids=SHAPE_IDS)
+def test_result_shape_is_referenced(name):
+    """An unreferenced shape binds nothing and would silently stop being checked."""
+    assert any(tool.get("resultShape") == name for tool in TOOLS), (
+        f"resultShape {name!r} is defined but no tool declares it"
+    )
+
+
+@pytest.mark.parametrize("name", SHAPE_IDS, ids=SHAPE_IDS)
+def test_result_shape_records_are_coherent(name):
+    """The record schema must be strict enough for the parity test to enforce it."""
+    shape = RESULT_SHAPES[name]
+    assert shape["type"] == "array", f"{name} must describe an array of records"
+    record = shape["items"]
+    assert record["type"] == "object"
+    properties = record["properties"]
+    assert set(record["required"]) == set(properties), (
+        f"{name}: every field must be required, so neither server may omit one"
+    )
+    assert record.get("additionalProperties") is False, (
+        f"{name}: extra fields must be forbidden, or the servers can still diverge"
+    )
+    for field, spec in properties.items():
+        assert spec.get("description", "").strip(), (
+            f"{name}.{field} has no description — the model relies on it"
+        )
+
+
+def test_the_history_family_shares_one_result_shape():
+    """The divergence in #23 was two tools, both servers; one shape covers all four."""
+    history_family = {t["name"]: t.get("resultShape") for t in TOOLS if t["capability"]}
+    assert history_family == {
+        "read_history_opcua_node": "historyRecords",
+        "read_aggregate_opcua_node": "historyRecords",
+    }

--- a/tests/unit/test_records.py
+++ b/tests/unit/test_records.py
@@ -1,0 +1,93 @@
+"""Unit tests for the canonical history-family record shape (Python side).
+
+`contract/tools.json` -> `resultShapes.historyRecords` defines one shape for
+`read_history_opcua_node` / `read_aggregate_opcua_node` on both servers; this
+file pins the Python implementation of it. The Node equivalent is the
+"history records" suite in packages/server-node/test/unit.test.mjs, and the two
+deliberately assert the same records.
+
+No OPC UA server and no MCP transport: `DataValue` is stood in for by a stub
+exposing the three attributes the mapper reads.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+from opcua_mcp_server import format_iso_utc, history_record, history_records, json_value
+
+TIMESTAMP = datetime(2026, 9, 9, 13, 36, 1, 468000)
+
+
+def data_value(value, *, timestamp=TIMESTAMP, status="Good"):
+    """A stand-in for an opcua `DataValue` — the attributes the mapper reads."""
+    return SimpleNamespace(
+        Value=SimpleNamespace(Value=value),
+        SourceTimestamp=timestamp,
+        StatusCode=None if status is None else SimpleNamespace(name=status),
+    )
+
+
+def test_flattens_a_data_value():
+    assert history_records([data_value(51.25)]) == [
+        {"value": 51.25, "timestamp": "2026-09-09T13:36:01.468000Z", "status": "Good"}
+    ]
+
+
+@pytest.mark.parametrize("value", [51.25, 3, True, False, "AUTO", None, [1.0, 2.0]])
+def test_json_native_values_pass_through_unstringified(value):
+    """The value used to be `str(...)`, so a number arrived as `"51.25"`."""
+    assert json_value(value) == value
+
+
+def test_empty_aggregate_interval_is_null_not_the_string_none():
+    """An interval the server has no data for previously came back as `"None"`."""
+    record = history_record(data_value(None, status="BadNoData"))
+    assert record["value"] is None
+    assert record["status"] == "BadNoData"
+
+
+def test_absent_status_code_means_good():
+    assert history_record(data_value(1, status=None))["status"] == "Good"
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_floats_become_strings(value):
+    """`json.dumps` would emit a bare `NaN`, which strict JSON parsers reject."""
+    assert json_value(value) == str(value)
+
+
+def test_values_json_cannot_carry_become_their_string_form():
+    assert json_value(datetime(2026, 9, 9, 13, 36)) == "2026-09-09 13:36:00"
+    assert json_value({"a": 1}) == "{'a': 1}"
+
+
+def test_no_data_values_is_an_empty_record_list():
+    assert history_records(None) == []
+    assert history_records([]) == []
+
+
+# --- format_iso_utc -----------------------------------------------------------
+
+
+def test_naive_timestamps_are_labelled_utc_not_reinterpreted_as_local():
+    """python-opcua decodes OPC UA DateTimes to naive datetimes already in UTC."""
+    assert format_iso_utc(TIMESTAMP) == "2026-09-09T13:36:01.468000Z"
+
+
+def test_aware_timestamps_are_converted_to_utc():
+    kolkata = timezone(timedelta(hours=5, minutes=30))
+    assert format_iso_utc(TIMESTAMP.replace(tzinfo=kolkata)) == "2026-09-09T08:06:01.468000Z"
+
+
+def test_none_passes_through():
+    assert format_iso_utc(None) is None
+
+
+def test_round_trips_through_the_parser_the_tools_accept():
+    """The tools accept ISO-8601 for start_time/end_time; they now return it too."""
+    from opcua_mcp_server import parse_iso_datetime
+
+    assert parse_iso_datetime(format_iso_utc(TIMESTAMP)) == TIMESTAMP.replace(tzinfo=timezone.utc)

--- a/tests/unit/test_records.py
+++ b/tests/unit/test_records.py
@@ -3,43 +3,125 @@
 `contract/tools.json` -> `resultShapes.historyRecords` defines one shape for
 `read_history_opcua_node` / `read_aggregate_opcua_node` on both servers; this
 file pins the Python implementation of it. The Node equivalent is the
-"history records" suite in packages/server-node/test/unit.test.mjs, and the two
-deliberately assert the same records.
+"history records" suite in packages/server-node/test/unit.test.mjs.
 
-No OPC UA server and no MCP transport: `DataValue` is stood in for by a stub
-exposing the three attributes the mapper reads.
+The per-type value encoding is not restated here — it lives in
+`tests/fixtures/value-encoding.json`, which both suites read. Each side builds
+the *native* value for a case (that is the whole problem: `bytes` here, a
+`Buffer` there) and asserts the same JSON comes out. A case with no native value
+below fails rather than silently going unchecked, so adding one to the fixture
+forces both runtimes to handle it.
+
+No OPC UA server and no MCP transport.
 """
 
 from __future__ import annotations
 
+import json
+import re
+import uuid
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
-from opcua_mcp_server import format_iso_utc, history_record, history_records, json_value
+from conftest import ROOT
+from opcua import ua
+from opcua_mcp_server import format_iso_utc, history_record, history_records, variant_to_json
 
 TIMESTAMP = datetime(2026, 9, 9, 13, 36, 1, 468000)
+
+FIXTURE = json.loads((ROOT / "tests" / "fixtures" / "value-encoding.json").read_text())
+CASES = {case["name"]: case for case in FIXTURE["cases"]}
+
+# The native python-opcua value for each case in the fixture. The Node suite has
+# its own table of the same names holding node-opcua values; the two produce the
+# same JSON, which is the point.
+NATIVE = {
+    "boolean": ua.Variant(True, ua.VariantType.Boolean),
+    "int32": ua.Variant(42, ua.VariantType.Int32),
+    "int64_small": ua.Variant(5, ua.VariantType.Int64),
+    "int64_negative": ua.Variant(-5, ua.VariantType.Int64),
+    "int64_beyond_double": ua.Variant(2**53 + 1, ua.VariantType.Int64),
+    "uint64_max": ua.Variant(2**64 - 1, ua.VariantType.UInt64),
+    "double": ua.Variant(51.75, ua.VariantType.Double),
+    "double_nan": ua.Variant(float("nan"), ua.VariantType.Double),
+    "double_infinity": ua.Variant(float("inf"), ua.VariantType.Double),
+    "string": ua.Variant("AUTO", ua.VariantType.String),
+    "datetime": ua.Variant(TIMESTAMP, ua.VariantType.DateTime),
+    "guid": ua.Variant(uuid.UUID("72962B91-FA75-4AE6-8D28-B404DC7DAF63"), ua.VariantType.Guid),
+    "bytestring": ua.Variant(b"abc", ua.VariantType.ByteString),
+    "nodeid": ua.Variant(ua.NodeId(3, 2), ua.VariantType.NodeId),
+    "statuscode": ua.Variant(ua.StatusCode(0), ua.VariantType.StatusCode),
+    "qualifiedname": ua.Variant(ua.QualifiedName("Temperature", 2), ua.VariantType.QualifiedName),
+    "localizedtext": ua.Variant(
+        ua.LocalizedText("Ambient temperature"), ua.VariantType.LocalizedText
+    ),
+    "double_array": ua.Variant([1.5, 2.5], ua.VariantType.Double),
+    "byte_array": ua.Variant([97, 98, 99], ua.VariantType.Byte),
+    "int64_array": ua.Variant([5, 2**53 + 1], ua.VariantType.Int64),
+    "bytestring_array": ua.Variant([b"ab", b"c"], ua.VariantType.ByteString),
+    "empty_array": ua.Variant([], ua.VariantType.Double),
+    "null": ua.Variant(None, ua.VariantType.Null),
+}
 
 
 def data_value(value, *, timestamp=TIMESTAMP, status="Good"):
     """A stand-in for an opcua `DataValue` — the attributes the mapper reads."""
     return SimpleNamespace(
-        Value=SimpleNamespace(Value=value),
+        Value=value if isinstance(value, ua.Variant) else SimpleNamespace(Value=value),
         SourceTimestamp=timestamp,
         StatusCode=None if status is None else SimpleNamespace(name=status),
     )
 
 
+# --- the shared value-encoding table ------------------------------------------
+
+
+def test_every_fixture_case_has_a_native_value():
+    """A case with no entry above would pass by never being run."""
+    assert set(NATIVE) == set(CASES), (
+        f"missing native values for {sorted(set(CASES) - set(NATIVE))}; "
+        f"unknown cases {sorted(set(NATIVE) - set(CASES))}"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(CASES), ids=sorted(CASES))
+def test_value_encoding_matches_the_shared_fixture(name):
+    """The Node suite asserts the same expectations against node-opcua values."""
+    case = CASES[name]
+    encoded = variant_to_json(NATIVE[name])
+
+    if "expectedPattern" in case:
+        assert isinstance(encoded, str) and re.match(case["expectedPattern"], encoded), (
+            f"{name}: {encoded!r} does not match {case['expectedPattern']!r}"
+        )
+    else:
+        assert encoded == case["expected"], f"{name}: {encoded!r} != {case['expected']!r}"
+
+
+@pytest.mark.parametrize("name", ["boolean", "int32", "double", "string"], ids=str)
+def test_json_native_values_are_not_stringified(name):
+    """The value used to be `str(...)`, so a number arrived as `"51.25"`."""
+    assert not isinstance(variant_to_json(NATIVE[name]), str) or name == "string"
+
+
+def test_bytestring_is_not_the_python_repr_of_bytes():
+    """Regression guard: `str(b"abc")` is `"b'abc'"`, which no other runtime emits."""
+    assert variant_to_json(NATIVE["bytestring"]) == "YWJj"
+
+
+def test_arrays_are_encoded_element_wise():
+    """One oversized Int64 element must not stringify its neighbours."""
+    assert variant_to_json(NATIVE["int64_array"]) == [5, "9007199254740993"]
+
+
+# --- the record ----------------------------------------------------------------
+
+
 def test_flattens_a_data_value():
-    assert history_records([data_value(51.25)]) == [
+    assert history_records([data_value(ua.Variant(51.25, ua.VariantType.Double))]) == [
         {"value": 51.25, "timestamp": "2026-09-09T13:36:01.468000Z", "status": "Good"}
     ]
-
-
-@pytest.mark.parametrize("value", [51.25, 3, True, False, "AUTO", None, [1.0, 2.0]])
-def test_json_native_values_pass_through_unstringified(value):
-    """The value used to be `str(...)`, so a number arrived as `"51.25"`."""
-    assert json_value(value) == value
 
 
 def test_empty_aggregate_interval_is_null_not_the_string_none():
@@ -51,17 +133,6 @@ def test_empty_aggregate_interval_is_null_not_the_string_none():
 
 def test_absent_status_code_means_good():
     assert history_record(data_value(1, status=None))["status"] == "Good"
-
-
-@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
-def test_non_finite_floats_become_strings(value):
-    """`json.dumps` would emit a bare `NaN`, which strict JSON parsers reject."""
-    assert json_value(value) == str(value)
-
-
-def test_values_json_cannot_carry_become_their_string_form():
-    assert json_value(datetime(2026, 9, 9, 13, 36)) == "2026-09-09 13:36:00"
-    assert json_value({"a": 1}) == "{'a': 1}"
 
 
 def test_no_data_values_is_an_empty_record_list():


### PR DESCRIPTION
## Summary

The Python and Node servers answered the same tool call with different shapes for `read_history_opcua_node` and `read_aggregate_opcua_node` — Node returned raw node-opcua `DataValue` JSON (`{"value": {"dataType": "Double", "value": 51.75}, "statusCode": {"value": 1}, "sourceTimestamp": …}`) while Python returned flat stringified records, so a client that learned one misread the other. `contract/tools.json` now declares the canonical shape under a new `resultShapes` section — `{ "value": 51.75, "timestamp": "2026-09-09T13:36:01.139Z", "status": "Good" }`, one record per historical value or aggregate interval, one MCP content block per record — and both servers produce it. Node moved to Python's framing rather than the reverse because FastMCP splits a returned list into one block per element and derives `structuredContent` from it, which a string return would give up. Three breaking changes fall out, all recorded in `CHANGELOG.md`: Node's nested fields flatten; Python timestamps become ISO-8601 UTC (so output now round-trips back into the `start_time`/`end_time` these tools already accept); and Python values keep their JSON type, so a Double is `51.75` rather than `"51.75"` and an empty aggregate interval is `null` rather than the string `"None"`.

Closes #23

## Type of change

- [ ] Bug fix
- [ ] New feature / new tool
- [ ] Documentation
- [x] Refactor / chore — behavioural, and **breaking** for consumers of either server's history output

## Affected implementation(s)

- [x] Python (`opcua-mcp-server`)
- [x] Node / TypeScript (`opcua-mcp-server`)
- [x] Tests / docs / CI only

## Checklist

- [x] If I added or changed a tool, I updated **both** servers (or explained why not).
- [x] I updated the README / docs (examples, testing) where relevant. Also `docs/architecture.md` and `CONTRIBUTING.md`, since the contract gained a concept.
- [x] I ran the end-to-end suite locally. 119 passed, 1 skipped; 8 smoke; 19 Node unit; ruff / prettier / tsc clean.
- [x] I added or updated tests covering the change.
- [x] I updated `CHANGELOG.md` under **Unreleased**.

## How to test

```bash
uv sync --all-packages
cd packages/server-node && npm install && npm run build && npm test && cd ../..
cd tests && uv run --no-sync pytest -v
```

The load-bearing tests:

- `tests/e2e/test_contract_parity.py::test_history_result_matches_the_contract_shape` reads the record schema out of `contract/tools.json` and validates each server's **real** output against it, so changing either server without changing the contract fails.
- `tests/e2e/test_mcp_e2e.py::test_read_history` now asserts the shape on both servers, replacing `assert "Good" in text or "sourceTimestamp" in text or "timestamp" in text`.
- `tests/e2e/test_aggregate_e2e.py` — its `aggregate_values` helper lost its per-implementation branch entirely, which is the clearest evidence the divergence is gone. Needs `npm install` in `packages/mock-server-aggregate` and Node ≥20, else it skips.

To see it by hand, with the mock running (`uv run --no-sync opcua-mock-server`):

```bash
npx -y @modelcontextprotocol/inspector --cli node packages/server-node/build/index.js \
  -e OPCUA_SERVER_URL=opc.tcp://localhost:4840/freeopcua/server/ \
  --method tools/call --tool-name read_history_opcua_node \
  --tool-arg 'node_id=ns=2;i=3' --tool-arg 'num_values=5'
```

Two judgement calls worth a reviewer's eye. **Sub-second precision still differs** — microseconds from Python, milliseconds from Node's `Date`; the contract permits it, since truncating Python would discard real OPC UA resolution to accommodate a JS limitation. And **Python advertises a FastMCP-derived `outputSchema` in `tools/list` while Node advertises none** — a divergence in schema *advertising* rather than in output, left for a follow-up because closing it means either mimicking FastMCP's `{"result": …}` wrapper in Node or pinning Python's return type.

No version bump here: `docs/releasing.md` bumps all three manifests together at release time, and this warrants 0.3.0 when that happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)